### PR TITLE
refactor: list accounts without decrypting the wallet

### DIFF
--- a/src/account.rs
+++ b/src/account.rs
@@ -1,24 +1,21 @@
-use crate::utils::{create_accounts_file, number_of_derived_accounts, DEFAULT_WALLETS_VAULT_PATH};
+use crate::utils::{
+    create_accounts_file, number_of_derived_accounts, Accounts, DEFAULT_WALLETS_VAULT_PATH,
+};
 use anyhow::{bail, Result};
 use fuels::prelude::*;
 use fuels::signers::wallet::Wallet;
-use std::path::{Path, PathBuf};
-
-/// Returns the next index for account generation
-pub(crate) fn get_next_wallet_index(path: &Path) -> Result<usize, Error> {
-    let number_of_derived = number_of_derived_accounts(path)?;
-    Ok(number_of_derived)
-}
+use std::path::PathBuf;
 
 pub(crate) fn new_account(path: Option<String>) -> Result<()> {
     let wallet_path = match &path {
         Some(path) => PathBuf::from(path),
         None => home::home_dir().unwrap().join(DEFAULT_WALLETS_VAULT_PATH),
     };
+    let existing_accounts = Accounts::from_dir(&wallet_path)?;
     if !wallet_path.join(".wallet").exists() {
         bail!("Wallet is not initialized, please initialize a wallet before creating an account! To initialize a wallet: \"forc-wallet init\"");
     }
-    let account_index = get_next_wallet_index(&wallet_path)?;
+    let account_index = number_of_derived_accounts(&wallet_path);
     println!("Generating account with index: {}", account_index);
     let derive_path = format!("m/44'/1179993420'/{}'/0/0", account_index);
     let password = rpassword::prompt_password(
@@ -28,8 +25,9 @@ pub(crate) fn new_account(path: Option<String>) -> Result<()> {
     let phrase = String::from_utf8(phrase_recovered)?;
     let wallet = Wallet::new_from_mnemonic_phrase_with_path(&phrase, None, &derive_path)?;
 
-    // Create/update existing .accounts file
-    create_accounts_file(&wallet_path, account_index + 1)?;
+    let mut account_addresses = Vec::from(existing_accounts.addresses());
+    account_addresses.push(wallet.address().to_string());
+    create_accounts_file(&wallet_path, account_addresses)?;
 
     println!("Wallet public address: {}", wallet.address());
     Ok(())

--- a/src/list.rs
+++ b/src/list.rs
@@ -1,14 +1,14 @@
-use crate::utils::{derived_wallets, DEFAULT_WALLETS_VAULT_PATH};
+use crate::utils::{Accounts, DEFAULT_WALLETS_VAULT_PATH};
 use crate::Error;
-use fuels::prelude::*;
 use std::path::{Path, PathBuf};
 
 /// Returns index - public address pair for derived accounts
 pub(crate) fn get_wallets_list(path: &Path) -> Result<Vec<(usize, String)>, Error> {
-    let wallets = derived_wallets(path)?
+    let wallets = Accounts::from_dir(path)?
+        .addresses()
         .iter()
         .enumerate()
-        .map(|(index, wallet)| (index, wallet.address().to_string()))
+        .map(|(index, address)| (index, address.clone()))
         .collect();
     Ok(wallets)
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -46,14 +46,14 @@ pub(crate) fn clear_wallets_vault(path: &Path) -> Result<()> {
     Ok(())
 }
 
-/// Create the `.accounts` file which holds the number of derived accounts so far
+/// Create the `.accounts` file which holds the addresses of accounts derived so far
 pub(crate) fn create_accounts_file(path: &Path, accounts: Vec<String>) -> Result<()> {
     let account_file = serde_json::to_string(&Accounts::new(accounts))?;
     fs::write(path.join(".accounts"), account_file)?;
     Ok(())
 }
 
-/// Read the number of accounts from `.accounts` file
+/// Returns the number of the accounts derived so far by reading the .accounts file from given path
 pub(crate) fn number_of_derived_accounts(path: &Path) -> usize {
     let accounts = Accounts::from_dir(path);
     if let Ok(accounts) = accounts {


### PR DESCRIPTION
closes #22.

I am planning to tackle #5 and this one is slightly relative as this changes the way we store list of derived account addresses. With #19 we were just holding the number of derived accounts so far and while listing we were deriving them all. With this PR, we are storing their public addresses so that we don't need to decrypt the wallet just to show the list of accounts.