### PR TITLE
feat: add the sign feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1185,6 +1185,7 @@ dependencies = [
  "fuel-crypto 0.6.0",
  "fuel-types",
  "fuels",
+ "fuels-signers",
  "home",
  "rand 0.8.5",
  "rpassword",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ eth-keystore = { version = "0.4" }
 fuel-crypto = "0.6"
 fuel-types = "0.5"
 fuels = { version = "0.20", default-features = false }
+fuels-signers = { version = "0.20.0" }
 home = "0.5.3"
 rand = { version = "0.8.4", default-features = false }
 rpassword = "6.0.1"

--- a/src/account.rs
+++ b/src/account.rs
@@ -2,8 +2,7 @@ use crate::utils::{
     create_accounts_file, number_of_derived_accounts, Accounts, DEFAULT_WALLETS_VAULT_PATH,
 };
 use anyhow::{bail, Result};
-use fuels::prelude::*;
-use fuels::signers::wallet::Wallet;
+use fuels::{prelude::*, signers::wallet::Wallet};
 use std::path::PathBuf;
 
 pub(crate) fn print_account_address(path: Option<String>, account_index: usize) -> Result<()> {
@@ -13,7 +12,7 @@ pub(crate) fn print_account_address(path: Option<String>, account_index: usize) 
     };
     let existing_accounts = Accounts::from_dir(&wallet_path)?;
     if let Some(account) = existing_accounts.addresses().iter().nth(account_index) {
-        println!("Account {} address: 0x{}", account_index, account);
+        println!("Account {} address: {}", account_index, account);
     } else {
         eprintln!("Account {} is not derived yet!", account_index);
     }
@@ -43,6 +42,7 @@ pub(crate) fn new_account(path: Option<String>) -> Result<()> {
     account_addresses.push(wallet.address().to_string());
     create_accounts_file(&wallet_path, account_addresses)?;
 
-    println!("Wallet public address: {}", wallet.address());
+    println!("Wallet address: {}", wallet.address());
+    println!("Wallet plain address: {}", wallet.address().hash());
     Ok(())
 }

--- a/src/account.rs
+++ b/src/account.rs
@@ -43,6 +43,5 @@ pub(crate) fn new_account(path: Option<String>) -> Result<()> {
     create_accounts_file(&wallet_path, account_addresses)?;
 
     println!("Wallet address: {}", wallet.address());
-    println!("Wallet plain address: {}", wallet.address().hash());
     Ok(())
 }

--- a/src/list.rs
+++ b/src/list.rs
@@ -23,12 +23,13 @@ pub(crate) fn print_wallet_list(path: Option<String>) -> Result<(), Error> {
         None => home::home_dir().unwrap().join(DEFAULT_WALLETS_VAULT_PATH),
     };
     let wallets = get_wallets_list(&wallet_path)?;
-    println!("#   address\n");
+    println!("#   address                                                         plain address\n");
     for wallet in wallets {
         let (index, address) = wallet;
         println!(
-            "[{}] 0x{}",
+            "[{}] {} 0x{}",
             index,
+            address,
             Bech32Address::from_str(&address)?.hash()
         )
     }

--- a/src/list.rs
+++ b/src/list.rs
@@ -1,10 +1,6 @@
 use crate::utils::{Accounts, DEFAULT_WALLETS_VAULT_PATH};
 use crate::Error;
-use fuels::prelude::*;
-use std::{
-    path::{Path, PathBuf},
-    str::FromStr,
-};
+use std::path::{Path, PathBuf};
 
 /// Returns index - public address pair for derived accounts
 pub(crate) fn get_wallets_list(path: &Path) -> Result<Vec<(usize, String)>, Error> {
@@ -23,15 +19,10 @@ pub(crate) fn print_wallet_list(path: Option<String>) -> Result<(), Error> {
         None => home::home_dir().unwrap().join(DEFAULT_WALLETS_VAULT_PATH),
     };
     let wallets = get_wallets_list(&wallet_path)?;
-    println!("#   address                                                         plain address\n");
+    println!("#   address\n");
     for wallet in wallets {
         let (index, address) = wallet;
-        println!(
-            "[{}] {} 0x{}",
-            index,
-            address,
-            Bech32Address::from_str(&address)?.hash()
-        )
+        println!("[{}] {}", index, address);
     }
     Ok(())
 }

--- a/src/list.rs
+++ b/src/list.rs
@@ -26,7 +26,11 @@ pub(crate) fn print_wallet_list(path: Option<String>) -> Result<(), Error> {
     println!("#   address\n");
     for wallet in wallets {
         let (index, address) = wallet;
-        println!("[{}] 0x{}", index, Bech32Address::from_str(&address)?.hash())
+        println!(
+            "[{}] 0x{}",
+            index,
+            Bech32Address::from_str(&address)?.hash()
+        )
     }
     Ok(())
 }

--- a/src/list.rs
+++ b/src/list.rs
@@ -1,6 +1,10 @@
 use crate::utils::{Accounts, DEFAULT_WALLETS_VAULT_PATH};
 use crate::Error;
-use std::path::{Path, PathBuf};
+use fuels::prelude::*;
+use std::{
+    path::{Path, PathBuf},
+    str::FromStr,
+};
 
 /// Returns index - public address pair for derived accounts
 pub(crate) fn get_wallets_list(path: &Path) -> Result<Vec<(usize, String)>, Error> {
@@ -22,7 +26,7 @@ pub(crate) fn print_wallet_list(path: Option<String>) -> Result<(), Error> {
     println!("#   address\n");
     for wallet in wallets {
         let (index, address) = wallet;
-        println!("[{}] {}", index, address);
+        println!("[{}] 0x{}", index, Bech32Address::from_str(&address)?.hash())
     }
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,6 +41,7 @@ enum Command {
         account_index: usize,
         path: Option<String>,
     },
+    /// Sign a transaction by providing its ID and the signing account's index
     Sign {
         id: String,
         account_index: usize,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,14 @@
 mod account;
 mod init;
 mod list;
+mod sign;
 mod utils;
 
 use crate::{
     account::{new_account, print_account_address},
     init::init_wallet,
     list::print_wallet_list,
+    sign::sign_transaction_manually,
 };
 use anyhow::Result;
 use clap::{ArgEnum, Parser, Subcommand};
@@ -39,6 +41,11 @@ enum Command {
         account_index: usize,
         path: Option<String>,
     },
+    Sign {
+        id: String,
+        account_index: usize,
+        path: Option<String>,
+    },
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, ArgEnum)]
@@ -60,6 +67,11 @@ async fn main() -> Result<()> {
             account_index,
             path,
         } => print_account_address(path, account_index)?,
+        Command::Sign {
+            id,
+            account_index,
+            path,
+        } => sign_transaction_manually(&id, account_index, path).await?,
     };
     Ok(())
 }

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -16,8 +16,8 @@ pub(crate) async fn sign_transaction_manually(
     };
     let tx_id = Bytes32::from_str(id).map_err(|e| anyhow!("{}", e))?;
     let secret_key = derive_account_with_index(&wallet_path, account_index)?;
-    let message = unsafe { Message::from_bytes_unchecked(*tx_id) };
-    let sig = Signature::sign(&secret_key, &message);
+    let message_hash = unsafe { Message::from_bytes_unchecked(*tx_id) };
+    let sig = Signature::sign(&secret_key, &message_hash);
     println!("Signature: {sig}");
     Ok(())
 }

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -1,0 +1,20 @@
+use std::str::FromStr;
+
+use crate::utils::get_account_from_store;
+use anyhow::Result;
+use fuel_crypto::Message;
+use fuels::prelude::*;
+use fuels_signers::{fuel_crypto::fuel_types::AssetId, Signer};
+
+pub(crate) async fn sign_transaction_manually(
+    id: &str,
+    account_index: usize,
+    path: Option<String>,
+) -> Result<(), Error> {
+    let asset_id = AssetId::from_str(id).unwrap();
+    let wallet = get_account_from_store(account_index, &path.unwrap_or_else(|| "".to_string()))?;
+    let message = unsafe { Message::from_bytes_unchecked(*asset_id) };
+    let sig = wallet.sign_message(message).await?;
+    println!("sig: {sig}");
+    Ok(())
+}

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -1,23 +1,23 @@
-use std::str::FromStr;
-
-use crate::{utils::get_account_from_store, DEFAULT_WALLETS_VAULT_PATH};
-use anyhow::Result;
+use crate::utils::{derive_account_with_index, DEFAULT_WALLETS_VAULT_PATH};
+use anyhow::{anyhow, Result};
 use fuel_crypto::Message;
 use fuels::prelude::*;
 use fuels_signers::{fuel_crypto::fuel_types::AssetId, Signer};
+use std::{path::PathBuf, str::FromStr};
 
 pub(crate) async fn sign_transaction_manually(
     id: &str,
     account_index: usize,
     path: Option<String>,
 ) -> Result<(), Error> {
-    let asset_id = AssetId::from_str(id).unwrap();
-    let wallet = get_account_from_store(
-        account_index,
-        &path.unwrap_or_else(|| DEFAULT_WALLETS_VAULT_PATH.to_string()),
-    )?;
+    let wallet_path = match &path {
+        Some(path) => PathBuf::from(path),
+        None => home::home_dir().unwrap().join(DEFAULT_WALLETS_VAULT_PATH),
+    };
+    let asset_id = AssetId::from_str(id).map_err(|e| anyhow!("{}", e))?;
+    let wallet = derive_account_with_index(&wallet_path, account_index)?;
     let message = unsafe { Message::from_bytes_unchecked(*asset_id) };
     let sig = wallet.sign_message(message).await?;
-    println!("sig: {sig}");
+    println!("Signature: {sig}");
     Ok(())
 }

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -1,8 +1,8 @@
 use crate::utils::{derive_account_with_index, DEFAULT_WALLETS_VAULT_PATH};
 use anyhow::{anyhow, Result};
-use fuel_crypto::Message;
+use fuel_crypto::{Message, Signature};
+use fuel_types::Bytes32;
 use fuels::prelude::*;
-use fuels_signers::{fuel_crypto::fuel_types::AssetId, Signer};
 use std::{path::PathBuf, str::FromStr};
 
 pub(crate) async fn sign_transaction_manually(
@@ -14,10 +14,10 @@ pub(crate) async fn sign_transaction_manually(
         Some(path) => PathBuf::from(path),
         None => home::home_dir().unwrap().join(DEFAULT_WALLETS_VAULT_PATH),
     };
-    let asset_id = AssetId::from_str(id).map_err(|e| anyhow!("{}", e))?;
-    let wallet = derive_account_with_index(&wallet_path, account_index)?;
-    let message = unsafe { Message::from_bytes_unchecked(*asset_id) };
-    let sig = wallet.sign_message(message).await?;
+    let tx_id = Bytes32::from_str(id).map_err(|e| anyhow!("{}", e))?;
+    let secret_key = derive_account_with_index(&wallet_path, account_index)?;
+    let message = unsafe { Message::from_bytes_unchecked(*tx_id) };
+    let sig = Signature::sign(&secret_key, &message);
     println!("Signature: {sig}");
     Ok(())
 }

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -1,6 +1,6 @@
 use std::str::FromStr;
 
-use crate::utils::get_account_from_store;
+use crate::{utils::get_account_from_store, DEFAULT_WALLETS_VAULT_PATH};
 use anyhow::Result;
 use fuel_crypto::Message;
 use fuels::prelude::*;
@@ -12,7 +12,10 @@ pub(crate) async fn sign_transaction_manually(
     path: Option<String>,
 ) -> Result<(), Error> {
     let asset_id = AssetId::from_str(id).unwrap();
-    let wallet = get_account_from_store(account_index, &path.unwrap_or_else(|| "".to_string()))?;
+    let wallet = get_account_from_store(
+        account_index,
+        &path.unwrap_or_else(|| DEFAULT_WALLETS_VAULT_PATH.to_string()),
+    )?;
     let message = unsafe { Message::from_bytes_unchecked(*asset_id) };
     let sig = wallet.sign_message(message).await?;
     println!("sig: {sig}");

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,5 @@
 use anyhow::{anyhow, Result};
+use fuels::signers::wallet::Wallet;
 use serde::{Deserialize, Serialize};
 use std::{fs, path::Path};
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -62,3 +62,14 @@ pub(crate) fn number_of_derived_accounts(path: &Path) -> usize {
         0
     }
 }
+
+pub(crate) fn derive_account_with_index(path: &Path, account_index: usize) -> Result<Wallet> {
+    let password = rpassword::prompt_password(
+        "Please enter your password to decrypt initialized wallet's phrases: ",
+    )?;
+    let phrase_recovered = eth_keystore::decrypt_key(path.join(".wallet"), password)?;
+    let phrase = String::from_utf8(phrase_recovered)?;
+    let derive_path = format!("m/44'/1179993420'/{}'/0/0", account_index);
+    let wallet = Wallet::new_from_mnemonic_phrase_with_path(&phrase, None, &derive_path)?;
+    Ok(wallet)
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,5 @@
 use anyhow::{anyhow, Result};
-use fuels::signers::wallet::Wallet;
+use fuel_crypto::SecretKey;
 use serde::{Deserialize, Serialize};
 use std::{fs, path::Path};
 
@@ -64,13 +64,13 @@ pub(crate) fn number_of_derived_accounts(path: &Path) -> usize {
     }
 }
 
-pub(crate) fn derive_account_with_index(path: &Path, account_index: usize) -> Result<Wallet> {
+pub(crate) fn derive_account_with_index(path: &Path, account_index: usize) -> Result<SecretKey> {
     let password = rpassword::prompt_password(
         "Please enter your password to decrypt initialized wallet's phrases: ",
     )?;
     let phrase_recovered = eth_keystore::decrypt_key(path.join(".wallet"), password)?;
     let phrase = String::from_utf8(phrase_recovered)?;
     let derive_path = format!("m/44'/1179993420'/{}'/0/0", account_index);
-    let wallet = Wallet::new_from_mnemonic_phrase_with_path(&phrase, None, &derive_path)?;
-    Ok(wallet)
+    let secret_key = SecretKey::new_from_mnemonic_phrase_with_path(&phrase, &derive_path)?;
+    Ok(secret_key)
 }


### PR DESCRIPTION
## About this PR
closes #7.

This PR introduces a new command `sign` to the `forc-wallet`. Currently `sign` accepts 2 parameters:

1. Transaction id
2. Account index of the account that we want to sign this transaction with

In this first iteration of development (where we are trying to enable our users to sign deployment transactions) The usual signing process while deploying a contract currently looks like the following:

1. Running `forc-deploy` will ask the user to input the address of the wallet they are going to be signing with. To get that the user can either run the `forc-wallet list` and look under the `address` section of the desired account or run `forc-wallet account <account_index>` to get the address. This reports a transaction id and waits for the signature.
2. User runs `forc-wallet sign <transaction_id> <account_index>` and `forc-wallet` asks for the password for the wallet as we do need to decrypt it before signing. If the password is correct, the signature is generated and reported back to the user.
3. In the meantime `forc-deploy` is waiting for the signature to be inserted, once the user inserts the generated signature from the `forc-wallet` it adds it to the witnesses and submits the transaction.

All the required functionality from the wallet's end is ready with this PR and once https://github.com/FuelLabs/sway/pull/2629 is merged `forc-deploy` will also behave as described.