### PR TITLE
feat: added `account` command to show address of an account given its index

### DIFF
--- a/src/account.rs
+++ b/src/account.rs
@@ -6,6 +6,20 @@ use fuels::prelude::*;
 use fuels::signers::wallet::Wallet;
 use std::path::PathBuf;
 
+pub(crate) fn print_account_address(path: Option<String>, account_index: usize) -> Result<()> {
+    let wallet_path = match &path {
+        Some(path) => PathBuf::from(path),
+        None => home::home_dir().unwrap().join(DEFAULT_WALLETS_VAULT_PATH),
+    };
+    let existing_accounts = Accounts::from_dir(&wallet_path)?;
+    if let Some(account) = existing_accounts.addresses().iter().nth(account_index) {
+        println!("Account {} address: 0x{}", account_index, account);
+    } else {
+        eprintln!("Account {} is not derived yet!", account_index);
+    }
+    Ok(())
+}
+
 pub(crate) fn new_account(path: Option<String>) -> Result<()> {
     let wallet_path = match &path {
         Some(path) => PathBuf::from(path),

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,11 @@ mod init;
 mod list;
 mod utils;
 
-use crate::{account::new_account, init::init_wallet, list::print_wallet_list};
+use crate::{
+    account::{new_account, print_account_address},
+    init::init_wallet,
+    list::print_wallet_list,
+};
 use anyhow::Result;
 use clap::{ArgEnum, Parser, Subcommand};
 use fuels::prelude::*;
@@ -30,6 +34,11 @@ enum Command {
     Init { path: Option<String> },
     /// Lists all accounts derived so far.
     List { path: Option<String> },
+    /// Get the address of an acccount from account index
+    Account {
+        account_index: usize,
+        path: Option<String>,
+    },
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, ArgEnum)]
@@ -47,6 +56,10 @@ async fn main() -> Result<()> {
         Command::New { path } => new_account(path)?,
         Command::List { path } => print_wallet_list(path)?,
         Command::Init { path } => init_wallet(path)?,
+        Command::Account {
+            account_index,
+            path,
+        } => print_account_address(path, account_index)?,
     };
     Ok(())
 }


### PR DESCRIPTION
## About this PR
closes #5.

Introduces `account` command which can be used for getting an account's public address from it's index.

```sh
forc-wallet account <account-index>
```

Example run:

```sh
$ forc-wallet account 0
Account 0 address: 0xfuel1nrtj75vvl6hp6czl0yhpe5p78qfud7fuk6gffekgtk58nkqn0j5qft8y7s
```