### PR TITLE
feat: Add --export to account to export account's private key

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ mod sign;
 mod utils;
 
 use crate::{
-    account::{new_account, print_account_address},
+    account::{new_account, print_account},
     init::init_wallet,
     list::print_wallet_list,
     sign::sign_transaction_manually,
@@ -44,6 +44,9 @@ enum Command {
     /// Get the address of an acccount from account index
     Account {
         account_index: usize,
+        #[clap(long)]
+        export: bool,
+        #[clap(long)]
         path: Option<String>,
     },
     /// Sign a transaction by providing its ID and the signing account's index
@@ -71,8 +74,9 @@ async fn main() -> Result<()> {
         Command::Init { import, path } => init_wallet(import, path)?,
         Command::Account {
             account_index,
+            export,
             path,
-        } => print_account_address(path, account_index)?,
+        } => print_account(path, account_index, export)?,
         Command::Sign {
             id,
             account_index,


### PR DESCRIPTION
closes #39.

This PR adds `--export` to `forc-wallet account` so that people can get their private key from their accounts managed by `forc-wallet` and use import and use them in SDKs. To not leak any private key in the terminal history it is shown in an alternate screen just like the seed phrase.  