### PR TITLE
Adds a CI check to ensure the lock file is always up to date

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
           - command: clippy
             args: --all-targets --all-features
           - command: check
-            args: --all-targets --all-features
+            args: --locked --all-targets --all-features
           - command: test
             args: --all-targets --all-features
           - command: test


### PR DESCRIPTION
Version 0.1.0 was published with an out-of-date lock file. This updates CI to ensure it's always at least up to date with the `Cargo.toml` requirements.