### PR TITLE
Bump version to v0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1177,7 +1177,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "forc-wallet"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forc-wallet"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 homepage = "https://fuel.network/"
 license = "Apache-2.0"


### PR DESCRIPTION
closes #46.

Waiting:

- [x] #47 
- [x] #45 
- [x] #50 