### PR TITLE
Fix error in the case of an non-existing vault path and refactor discrete string utility

### DIFF
--- a/src/export.rs
+++ b/src/export.rs
@@ -1,6 +1,5 @@
 use crate::utils::{
     derive_account_with_index, display_string_discreetly, handle_vault_path_argument,
-    wait_for_keypress,
 };
 use anyhow::Result;
 
@@ -9,9 +8,7 @@ pub(crate) fn export_account(path: Option<String>, account_index: usize) -> Resu
 
     let secret_key = derive_account_with_index(&vault_path, account_index)?;
     let secret_key_string = format!("Secret key for account {}: {}\n", account_index, secret_key);
-    display_string_discreetly(secret_key_string)?;
-    println!("### Press any key to complete. ###");
-    wait_for_keypress();
+    display_string_discreetly(&secret_key_string, "### Press any key to complete. ###")?;
 
     Ok(())
 }

--- a/src/import.rs
+++ b/src/import.rs
@@ -7,10 +7,11 @@ pub(crate) fn import_wallet(path: Option<String>) -> Result<(), Error> {
     if vault_path.exists() {
         // TODO(?): add CLI interactivity to override
         return Err(Error::WalletError(format!(
-            "Cannot import wallet at {:?}, the directory already exists!",
+            "Cannot import wallet at {:?}, the directory already exists! You can clear the given path and re-use the same path",
             vault_path
         )));
     }
+    std::fs::create_dir_all(&vault_path)?;
 
     let mnemonic = rpassword::prompt_password("Please enter your mnemonic phrase: ")?;
     // Check users's phrase by trying to create a wallet from it

--- a/src/init.rs
+++ b/src/init.rs
@@ -1,6 +1,4 @@
-use crate::utils::{
-    display_string_discreetly, handle_vault_path_argument, request_new_password, wait_for_keypress,
-};
+use crate::utils::{display_string_discreetly, handle_vault_path_argument, request_new_password};
 use crate::Error;
 use fuels::signers::wallet::generate_mnemonic_phrase;
 
@@ -9,10 +7,12 @@ pub(crate) fn init_wallet(path: Option<String>) -> Result<(), Error> {
     if vault_path.exists() {
         // TODO(?): add CLI interactivity to override
         return Err(Error::WalletError(format!(
-            "Cannot init vault at {:?}, the directory already exists!",
+            "Cannot init vault at {:?}, the directory already exists! You can clear the given path and re-use the same path",
             vault_path
         )));
     }
+    std::fs::create_dir_all(&vault_path)?;
+
     // Generate mnemonic phrase
     let mnemonic = generate_mnemonic_phrase(&mut rand::thread_rng(), 24)?;
     // Encrypt and store it
@@ -33,8 +33,9 @@ pub(crate) fn init_wallet(path: Option<String>) -> Result<(), Error> {
         )
     });
     let mnemonic_string = format!("Wallet mnemonic phrase: {}\n", mnemonic);
-    display_string_discreetly(mnemonic_string)?;
-    println!("### Do not share or lose this mnemonic phrase! Press any key to complete. ###");
-    wait_for_keypress();
+    display_string_discreetly(
+        &mnemonic_string,
+        "### Do not share or lose this mnemonic phrase! Press any key to complete. ###",
+    )?;
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,14 +36,12 @@ struct App {
 enum Command {
     /// Generate a new account for the initialized HD wallet.
     New { path: Option<String> },
-    /// Initialize the HD wallet from a random mnemonic phrase. If it is already initialized this
-    /// will remove the old one.
+    /// Initialize the HD wallet from a random mnemonic phrase.
     Init {
         #[clap(long)]
         path: Option<String>,
     },
-    /// Initialize the HD wallet from the provided mnemonic phrase. If it is already initialized this
-    /// will remove the old one.
+    /// Initialize the HD wallet from the provided mnemonic phrase.
     Import {
         #[clap(long)]
         path: Option<String>,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -91,10 +91,16 @@ pub(crate) fn request_new_password() -> String {
 }
 
 /// Print a string to an alternate screen, so the string isn't printed to the terminal.
-pub(crate) fn display_string_discreetly(discreet_string: String) -> Result<(), Error> {
+pub(crate) fn display_string_discreetly(
+    discreet_string: &str,
+    continue_message: &str,
+) -> Result<(), Error> {
     let mut screen = AlternateScreen::from(std::io::stdout());
     writeln!(screen, "{}", discreet_string)?;
-    Ok(screen.flush()?)
+    screen.flush()?;
+    println!("{}", continue_message);
+    wait_for_keypress();
+    Ok(())
 }
 
 /// Handle the default path argument and return the right path, error out if the path is not


### PR DESCRIPTION
closes #52.
closes #53.
Also slightly improves the error message for existing vault path.

Since these are affecting our users rn, I wanted to get them out as soon as possible hence they are in the same PR. 