### PR TITLE
test/refactor: Add tests for existing wallet operations and split CLI and the actual logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1173,6 +1173,7 @@ dependencies = [
  "rpassword",
  "serde",
  "serde_json",
+ "serial_test",
  "termion",
  "tiny-bip39",
  "tokio",
@@ -2764,6 +2765,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
 dependencies = [
  "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serial_test"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92761393ee4dc3ff8f4af487bd58f4307c9329bbedea02cac0089ad9c411e153"
+dependencies = [
+ "dashmap",
+ "futures",
+ "lazy_static",
+ "log",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b6f5d1c3087fb119617cff2966fe3808a80e5eb59a8c1601d5994d66f4346a5"
+dependencies = [
+ "proc-macro-error",
  "proc-macro2",
  "quote",
  "syn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,6 @@ termion = "1.5.6"
 tiny-bip39 = "0.8"
 tokio = { version = "1.10.1", features = ["full"] }
 toml = "0.5"
+
+[dev-dependencies]
+serial_test = "*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,4 +28,4 @@ tokio = { version = "1.10.1", features = ["full"] }
 toml = "0.5"
 
 [dev-dependencies]
-serial_test = "*"
+serial_test = "0.9"

--- a/src/account.rs
+++ b/src/account.rs
@@ -1,12 +1,12 @@
 use crate::utils::{
-    create_accounts_file, get_derivation_path, handle_vault_path_argument,
-    number_of_derived_accounts, Accounts,
+    create_accounts_file, get_derivation_path, handle_vault_path, number_of_derived_accounts,
+    Accounts,
 };
 use anyhow::{bail, Result};
 use fuels::prelude::WalletUnlocked;
 
 pub(crate) fn print_account_address(path: Option<String>, account_index: usize) -> Result<()> {
-    let vault_path = handle_vault_path_argument(path)?;
+    let vault_path = handle_vault_path(false, path)?;
     let existing_accounts = Accounts::from_dir(&vault_path)?;
     if let Some(account) = existing_accounts.addresses().iter().nth(account_index) {
         println!("Account {} address: {}", account_index, account);
@@ -17,7 +17,7 @@ pub(crate) fn print_account_address(path: Option<String>, account_index: usize) 
 }
 
 pub(crate) fn new_account(path: Option<String>) -> Result<()> {
-    let vault_path = handle_vault_path_argument(path)?;
+    let vault_path = handle_vault_path(false, path)?;
     let existing_accounts = Accounts::from_dir(&vault_path)?;
     if !vault_path.join(".wallet").exists() {
         bail!("Wallet is not initialized, please initialize a wallet before creating an account! To initialize a wallet: \"forc-wallet init\"");

--- a/src/account.rs
+++ b/src/account.rs
@@ -6,8 +6,8 @@ use anyhow::{bail, Result};
 use fuels::prelude::WalletUnlocked;
 use std::path::{Path, PathBuf};
 
-pub(crate) fn print_account_address(path_opt: Option<String>, account_index: usize) -> Result<()> {
-    let path = path_opt.map_or_else(default_vault_path, PathBuf::from);
+pub(crate) fn print_account_address(path_opt: Option<PathBuf>, account_index: usize) -> Result<()> {
+    let path = path_opt.unwrap_or_else(default_vault_path);
     validate_vault_path(&path)?;
     let existing_accounts = Accounts::from_dir(&path)?;
     if let Some(account) = existing_accounts.addresses().iter().nth(account_index) {
@@ -30,8 +30,8 @@ fn new_account(vault_path: &Path, password: &str) -> Result<WalletUnlocked> {
     Ok(wallet)
 }
 
-pub(crate) fn new_account_cli(path_opt: Option<String>) -> Result<()> {
-    let path = path_opt.map_or_else(default_vault_path, PathBuf::from);
+pub(crate) fn new_account_cli(path_opt: Option<PathBuf>) -> Result<()> {
+    let path = path_opt.unwrap_or_else(default_vault_path);
     validate_vault_path(&path)?;
     let existing_accounts = Accounts::from_dir(&path)?;
     if !path.join(".wallet").exists() {

--- a/src/account.rs
+++ b/src/account.rs
@@ -4,10 +4,11 @@ use crate::utils::{
 };
 use anyhow::{bail, Result};
 use fuels::prelude::WalletUnlocked;
+use std::path::PathBuf;
 
 pub(crate) fn print_account_address(path: Option<String>, account_index: usize) -> Result<()> {
     let vault_path = handle_vault_path(false, path)?;
-    let existing_accounts = Accounts::from_dir(&vault_path)?;
+    let existing_accounts = Accounts::from_dir(vault_path)?;
     if let Some(account) = existing_accounts.addresses().iter().nth(account_index) {
         println!("Account {} address: {}", account_index, account);
     } else {
@@ -16,21 +17,32 @@ pub(crate) fn print_account_address(path: Option<String>, account_index: usize) 
     Ok(())
 }
 
-pub(crate) fn new_account(path: Option<String>) -> Result<()> {
+fn new_account<P>(vault_path: P, password: &str) -> Result<WalletUnlocked>
+where
+    P: Into<PathBuf>,
+{
+    let vault_path_buf = vault_path.into();
+    let account_index = number_of_derived_accounts(&vault_path_buf);
+    println!("Generating account with index: {}", account_index);
+    let derive_path = get_derivation_path(account_index);
+
+    let phrase_recovered = eth_keystore::decrypt_key(vault_path_buf.join(".wallet"), password)?;
+    let phrase = String::from_utf8(phrase_recovered)?;
+    let wallet = WalletUnlocked::new_from_mnemonic_phrase_with_path(&phrase, None, &derive_path)?;
+    Ok(wallet)
+}
+
+pub(crate) fn new_account_cli(path: Option<String>) -> Result<()> {
     let vault_path = handle_vault_path(false, path)?;
-    let existing_accounts = Accounts::from_dir(&vault_path)?;
+    let existing_accounts = Accounts::from_dir(vault_path.clone())?;
     if !vault_path.join(".wallet").exists() {
         bail!("Wallet is not initialized, please initialize a wallet before creating an account! To initialize a wallet: \"forc-wallet init\"");
     }
-    let account_index = number_of_derived_accounts(&vault_path);
-    println!("Generating account with index: {}", account_index);
-    let derive_path = get_derivation_path(account_index);
     let password = rpassword::prompt_password(
         "Please enter your password to decrypt initialized wallet's phrases: ",
     )?;
-    let phrase_recovered = eth_keystore::decrypt_key(vault_path.join(".wallet"), password)?;
-    let phrase = String::from_utf8(phrase_recovered)?;
-    let wallet = WalletUnlocked::new_from_mnemonic_phrase_with_path(&phrase, None, &derive_path)?;
+
+    let wallet = new_account(&vault_path, &password)?;
 
     let mut account_addresses = Vec::from(existing_accounts.addresses());
     account_addresses.push(wallet.address().to_string());
@@ -38,4 +50,22 @@ pub(crate) fn new_account(path: Option<String>) -> Result<()> {
 
     println!("Wallet address: {}", wallet.address());
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::utils::test_utils::{save_dummy_wallet_file, with_tmp_folder, TEST_PASSWORD};
+    use serial_test::serial;
+
+    #[test]
+    #[serial]
+    fn create_new_account() {
+        with_tmp_folder(|tmp_folder| {
+            // init test wallet
+            save_dummy_wallet_file(tmp_folder);
+            let account_is_ok = new_account(tmp_folder, TEST_PASSWORD).is_ok();
+            assert!(account_is_ok)
+        });
+    }
 }

--- a/src/export.rs
+++ b/src/export.rs
@@ -1,7 +1,7 @@
 use crate::utils::{derive_account_with_index, display_string_discreetly, handle_vault_path};
 use anyhow::Result;
 
-pub(crate) fn export_account(path: Option<String>, account_index: usize) -> Result<()> {
+pub(crate) fn export_account_cli(path: Option<String>, account_index: usize) -> Result<()> {
     let vault_path = handle_vault_path(false, path)?;
 
     let password = rpassword::prompt_password(

--- a/src/export.rs
+++ b/src/export.rs
@@ -1,13 +1,18 @@
-use crate::utils::{derive_account_with_index, display_string_discreetly, handle_vault_path};
+use std::path::PathBuf;
+
+use crate::utils::{
+    default_vault_path, derive_account_with_index, display_string_discreetly, validate_vault_path,
+};
 use anyhow::Result;
 
-pub(crate) fn export_account_cli(path: Option<String>, account_index: usize) -> Result<()> {
-    let vault_path = handle_vault_path(false, path)?;
+pub(crate) fn export_account_cli(path_opt: Option<String>, account_index: usize) -> Result<()> {
+    let path = path_opt.map_or_else(default_vault_path, PathBuf::from);
+    validate_vault_path(&path)?;
 
     let password = rpassword::prompt_password(
         "Please enter your password to decrypt initialized wallet's phrases: ",
     )?;
-    let secret_key = derive_account_with_index(&vault_path, account_index, &password)?;
+    let secret_key = derive_account_with_index(&path, account_index, &password)?;
     let secret_key_string = format!("Secret key for account {}: {}\n", account_index, secret_key);
     display_string_discreetly(&secret_key_string, "### Press any key to complete. ###")?;
 

--- a/src/export.rs
+++ b/src/export.rs
@@ -5,8 +5,8 @@ use crate::utils::{
 };
 use anyhow::Result;
 
-pub(crate) fn export_account_cli(path_opt: Option<String>, account_index: usize) -> Result<()> {
-    let path = path_opt.map_or_else(default_vault_path, PathBuf::from);
+pub(crate) fn export_account_cli(path_opt: Option<PathBuf>, account_index: usize) -> Result<()> {
+    let path = path_opt.unwrap_or_else(default_vault_path);
     validate_vault_path(&path)?;
 
     let password = rpassword::prompt_password(

--- a/src/export.rs
+++ b/src/export.rs
@@ -1,10 +1,8 @@
-use crate::utils::{
-    derive_account_with_index, display_string_discreetly, handle_vault_path_argument,
-};
+use crate::utils::{derive_account_with_index, display_string_discreetly, handle_vault_path};
 use anyhow::Result;
 
 pub(crate) fn export_account(path: Option<String>, account_index: usize) -> Result<()> {
-    let vault_path = handle_vault_path_argument(path)?;
+    let vault_path = handle_vault_path(false, path)?;
 
     let password = rpassword::prompt_password(
         "Please enter your password to decrypt initialized wallet's phrases: ",

--- a/src/export.rs
+++ b/src/export.rs
@@ -6,7 +6,10 @@ use anyhow::Result;
 pub(crate) fn export_account(path: Option<String>, account_index: usize) -> Result<()> {
     let vault_path = handle_vault_path_argument(path)?;
 
-    let secret_key = derive_account_with_index(&vault_path, account_index)?;
+    let password = rpassword::prompt_password(
+        "Please enter your password to decrypt initialized wallet's phrases: ",
+    )?;
+    let secret_key = derive_account_with_index(&vault_path, account_index, &password)?;
     let secret_key_string = format!("Secret key for account {}: {}\n", account_index, secret_key);
     display_string_discreetly(&secret_key_string, "### Press any key to complete. ###")?;
 

--- a/src/import.rs
+++ b/src/import.rs
@@ -1,11 +1,14 @@
+use std::path::PathBuf;
+
 use crate::{
-    utils::{handle_vault_path, request_new_password, save_phrase_to_disk},
+    utils::{default_vault_path, request_new_password, save_phrase_to_disk, validate_vault_path},
     Error,
 };
 use fuels::signers::wallet::WalletUnlocked;
 
-pub(crate) fn import_wallet_cli(path: Option<String>) -> Result<(), Error> {
-    let vault_path = handle_vault_path(true, path)?;
+pub(crate) fn import_wallet_cli(path_opt: Option<String>) -> Result<(), Error> {
+    let path = path_opt.map_or_else(default_vault_path, PathBuf::from);
+    validate_vault_path(&path)?;
     let mnemonic = rpassword::prompt_password("Please enter your mnemonic phrase: ")?;
     // Check users's phrase by trying to create a wallet from it
     if WalletUnlocked::new_from_mnemonic_phrase(&mnemonic, None).is_err() {
@@ -17,7 +20,7 @@ pub(crate) fn import_wallet_cli(path: Option<String>) -> Result<(), Error> {
     }
     let password = request_new_password();
     // Encyrpt and store it
-    save_phrase_to_disk(&vault_path, &mnemonic, &password);
+    save_phrase_to_disk(&path, &mnemonic, &password);
 
     Ok(())
 }

--- a/src/import.rs
+++ b/src/import.rs
@@ -1,26 +1,43 @@
+use crate::utils::{
+    default_vault_path, request_new_password, save_phrase_to_disk, validate_vault_path,
+};
+use anyhow::{bail, Result};
+use fuels::signers::wallet::WalletUnlocked;
 use std::path::PathBuf;
 
-use crate::{
-    utils::{default_vault_path, request_new_password, save_phrase_to_disk, validate_vault_path},
-    Error,
-};
-use fuels::signers::wallet::WalletUnlocked;
+/// Check if given mnemonic is valid by trying to create a `WalletUnlocked` from it
+fn check_mnemonic(mnemonic: &str) -> Result<()> {
+    // Check users's phrase by trying to create a wallet from it
+    if WalletUnlocked::new_from_mnemonic_phrase(mnemonic, None).is_err() {
+        bail!("Cannot generate a wallet from provided mnemonics, please check your mnemonic phrase")
+    }
+    Ok(())
+}
 
-pub(crate) fn import_wallet_cli(path_opt: Option<String>) -> Result<(), Error> {
+pub(crate) fn import_wallet_cli(path_opt: Option<String>) -> Result<()> {
     let path = path_opt.map_or_else(default_vault_path, PathBuf::from);
     validate_vault_path(&path)?;
     let mnemonic = rpassword::prompt_password("Please enter your mnemonic phrase: ")?;
-    // Check users's phrase by trying to create a wallet from it
-    if WalletUnlocked::new_from_mnemonic_phrase(&mnemonic, None).is_err() {
-        return Err(Error::WalletError(
-            "Cannot generate a wallet from provided mnemonics, please \
-        check your mnemonic phrase"
-                .to_string(),
-        ));
-    }
+    check_mnemonic(&mnemonic)?;
     let password = request_new_password();
     // Encyrpt and store it
     save_phrase_to_disk(&path, &mnemonic, &password);
-
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::utils::test_utils::TEST_MNEMONIC;
+
+    #[test]
+    fn check_mnemonic_should_succeed() {
+        assert!(check_mnemonic(TEST_MNEMONIC).is_ok())
+    }
+
+    #[test]
+    fn check_mnemonic_should_fail() {
+        let invalid_mnemonic = "this is an invalid mnemonic";
+        assert!(check_mnemonic(invalid_mnemonic).is_err())
+    }
 }

--- a/src/import.rs
+++ b/src/import.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use fuels::signers::wallet::WalletUnlocked;
 
-pub(crate) fn import_wallet(path: Option<String>) -> Result<(), Error> {
+pub(crate) fn import_wallet_cli(path: Option<String>) -> Result<(), Error> {
     let vault_path = handle_vault_path(true, path)?;
     let mnemonic = rpassword::prompt_password("Please enter your mnemonic phrase: ")?;
     // Check users's phrase by trying to create a wallet from it

--- a/src/import.rs
+++ b/src/import.rs
@@ -14,8 +14,8 @@ fn check_mnemonic(mnemonic: &str) -> Result<()> {
     Ok(())
 }
 
-pub(crate) fn import_wallet_cli(path_opt: Option<String>) -> Result<()> {
-    let path = path_opt.map_or_else(default_vault_path, PathBuf::from);
+pub(crate) fn import_wallet_cli(path_opt: Option<PathBuf>) -> Result<()> {
+    let path = path_opt.unwrap_or_else(default_vault_path);
     validate_vault_path(&path)?;
     let mnemonic = rpassword::prompt_password("Please enter your mnemonic phrase: ")?;
     check_mnemonic(&mnemonic)?;

--- a/src/import.rs
+++ b/src/import.rs
@@ -1,5 +1,7 @@
-use crate::utils::{handle_vault_path_argument, request_new_password};
-use crate::Error;
+use crate::{
+    utils::{handle_vault_path_argument, request_new_password, save_phrase_to_disk},
+    Error,
+};
 use fuels::signers::wallet::WalletUnlocked;
 
 pub(crate) fn import_wallet(path: Option<String>) -> Result<(), Error> {
@@ -22,22 +24,9 @@ pub(crate) fn import_wallet(path: Option<String>) -> Result<(), Error> {
                 .to_string(),
         ));
     }
-    // Encyrpt and store it
-    let mnemonic_bytes: Vec<u8> = mnemonic.bytes().collect();
     let password = request_new_password();
+    // Encyrpt and store it
+    save_phrase_to_disk(&vault_path, &mnemonic, &password);
 
-    eth_keystore::encrypt_key(
-        &vault_path,
-        &mut rand::thread_rng(),
-        mnemonic_bytes,
-        &password,
-        Some(".wallet"),
-    )
-    .unwrap_or_else(|error| {
-        panic!(
-            "Cannot import eth_keystore at {:?}: {:?}",
-            vault_path, error
-        )
-    });
     Ok(())
 }

--- a/src/import.rs
+++ b/src/import.rs
@@ -1,20 +1,11 @@
 use crate::{
-    utils::{handle_vault_path_argument, request_new_password, save_phrase_to_disk},
+    utils::{handle_vault_path, request_new_password, save_phrase_to_disk},
     Error,
 };
 use fuels::signers::wallet::WalletUnlocked;
 
 pub(crate) fn import_wallet(path: Option<String>) -> Result<(), Error> {
-    let vault_path = handle_vault_path_argument(path)?;
-    if vault_path.exists() {
-        // TODO(?): add CLI interactivity to override
-        return Err(Error::WalletError(format!(
-            "Cannot import wallet at {:?}, the directory already exists! You can clear the given path and re-use the same path",
-            vault_path
-        )));
-    }
-    std::fs::create_dir_all(&vault_path)?;
-
+    let vault_path = handle_vault_path(true, path)?;
     let mnemonic = rpassword::prompt_password("Please enter your mnemonic phrase: ")?;
     // Check users's phrase by trying to create a wallet from it
     if WalletUnlocked::new_from_mnemonic_phrase(&mnemonic, None).is_err() {

--- a/src/init.rs
+++ b/src/init.rs
@@ -5,11 +5,12 @@ use crate::{
     Error,
 };
 use fuels::signers::wallet::generate_mnemonic_phrase;
+use std::{fmt::Debug, path::Path};
 
-fn init_wallet<P: AsRef<std::path::Path> + std::fmt::Debug>(
-    path: &P,
-    password: &str,
-) -> Result<String, Error> {
+fn init_wallet<P>(path: P, password: &str) -> Result<String, Error>
+where
+    P: AsRef<Path> + Debug,
+{
     // Generate mnemonic phrase
     let mnemonic = generate_mnemonic_phrase(&mut rand::thread_rng(), 24)?;
     // Encrypt and store it

--- a/src/init.rs
+++ b/src/init.rs
@@ -16,8 +16,8 @@ fn init_wallet(path: &Path, password: &str) -> Result<String, Error> {
     Ok(mnemonic)
 }
 
-pub(crate) fn init_wallet_cli(path_opt: Option<String>) -> Result<(), Error> {
-    let path = path_opt.map_or_else(default_vault_path, PathBuf::from);
+pub(crate) fn init_wallet_cli(path_opt: Option<PathBuf>) -> Result<(), Error> {
+    let path = path_opt.unwrap_or_else(default_vault_path);
     validate_vault_path(&path)?;
     create_vault(&path)?;
     let password = request_new_password();

--- a/src/init.rs
+++ b/src/init.rs
@@ -1,27 +1,27 @@
 use crate::{
     utils::{
-        display_string_discreetly, handle_vault_path, request_new_password, save_phrase_to_disk,
+        create_vault, default_vault_path, display_string_discreetly, request_new_password,
+        save_phrase_to_disk, validate_vault_path,
     },
     Error,
 };
 use fuels::signers::wallet::generate_mnemonic_phrase;
-use std::{fmt::Debug, path::Path};
+use std::path::{Path, PathBuf};
 
-fn init_wallet<P>(path: P, password: &str) -> Result<String, Error>
-where
-    P: AsRef<Path> + Debug,
-{
+fn init_wallet(path: &Path, password: &str) -> Result<String, Error> {
     // Generate mnemonic phrase
     let mnemonic = generate_mnemonic_phrase(&mut rand::thread_rng(), 24)?;
     // Encrypt and store it
-    save_phrase_to_disk(&path, &mnemonic, password);
+    save_phrase_to_disk(path, &mnemonic, password);
     Ok(mnemonic)
 }
 
-pub(crate) fn init_wallet_cli(path: Option<String>) -> Result<(), Error> {
-    let vault_path = handle_vault_path(true, path)?;
+pub(crate) fn init_wallet_cli(path_opt: Option<String>) -> Result<(), Error> {
+    let path = path_opt.map_or_else(default_vault_path, PathBuf::from);
+    validate_vault_path(&path)?;
+    create_vault(&path)?;
     let password = request_new_password();
-    let mnemonic = init_wallet(&vault_path, &password)?;
+    let mnemonic = init_wallet(&path, &password)?;
     let mnemonic_string = format!("Wallet mnemonic phrase: {}\n", mnemonic);
     display_string_discreetly(
         &mnemonic_string,

--- a/src/init.rs
+++ b/src/init.rs
@@ -1,33 +1,48 @@
 use crate::{
     utils::{
-        display_string_discreetly, handle_vault_path_argument, request_new_password,
-        save_phrase_to_disk,
+        display_string_discreetly, handle_vault_path, request_new_password, save_phrase_to_disk,
     },
     Error,
 };
 use fuels::signers::wallet::generate_mnemonic_phrase;
 
-pub(crate) fn init_wallet(path: Option<String>) -> Result<(), Error> {
-    let vault_path = handle_vault_path_argument(path)?;
-    if vault_path.exists() {
-        // TODO(?): add CLI interactivity to override
-        return Err(Error::WalletError(format!(
-            "Cannot init vault at {:?}, the directory already exists! You can clear the given path and re-use the same path",
-            vault_path
-        )));
-    }
-    std::fs::create_dir_all(&vault_path)?;
-
-    let password = request_new_password();
+fn init_wallet<P: AsRef<std::path::Path> + std::fmt::Debug>(
+    path: &P,
+    password: &str,
+) -> Result<String, Error> {
     // Generate mnemonic phrase
     let mnemonic = generate_mnemonic_phrase(&mut rand::thread_rng(), 24)?;
     // Encrypt and store it
-    save_phrase_to_disk(&vault_path, &mnemonic, &password);
+    save_phrase_to_disk(&path, &mnemonic, password);
+    Ok(mnemonic)
+}
 
+pub(crate) fn init_wallet_cli(path: Option<String>) -> Result<(), Error> {
+    let vault_path = handle_vault_path(true, path)?;
+    let password = request_new_password();
+    let mnemonic = init_wallet(&vault_path, &password)?;
     let mnemonic_string = format!("Wallet mnemonic phrase: {}\n", mnemonic);
     display_string_discreetly(
         &mnemonic_string,
         "### Do not share or lose this mnemonic phrase! Press any key to complete. ###",
     )?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::utils::test_utils::with_tmp_folder;
+    use fuels::signers::WalletUnlocked;
+    use serial_test::serial;
+
+    #[serial]
+    #[test]
+    fn initialize_wallet() {
+        with_tmp_folder(|tmp_folder| {
+            let mnemonic = init_wallet(tmp_folder, "1234").unwrap();
+            let wallet_success = WalletUnlocked::new_from_mnemonic_phrase(&mnemonic, None).is_ok();
+            assert!(wallet_success)
+        })
+    }
 }

--- a/src/init.rs
+++ b/src/init.rs
@@ -32,7 +32,7 @@ pub(crate) fn init_wallet_cli(path: Option<String>) -> Result<(), Error> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::utils::test_utils::with_tmp_folder;
+    use crate::utils::test_utils::{with_tmp_folder, TEST_PASSWORD};
     use fuels::signers::WalletUnlocked;
     use serial_test::serial;
 
@@ -40,7 +40,7 @@ mod tests {
     #[test]
     fn initialize_wallet() {
         with_tmp_folder(|tmp_folder| {
-            let mnemonic = init_wallet(tmp_folder, "1234").unwrap();
+            let mnemonic = init_wallet(tmp_folder, TEST_PASSWORD).unwrap();
             let wallet_success = WalletUnlocked::new_from_mnemonic_phrase(&mnemonic, None).is_ok();
             assert!(wallet_success)
         })

--- a/src/list.rs
+++ b/src/list.rs
@@ -1,10 +1,13 @@
 use crate::utils::{handle_vault_path, Accounts};
 use crate::Error;
-use std::path::Path;
+use std::path::PathBuf;
 
 /// Returns index - public address pair for derived accounts
-pub(crate) fn get_wallets_list(path: &Path) -> Result<Vec<(usize, String)>, Error> {
-    let wallets = Accounts::from_dir(path)?
+pub(crate) fn get_wallets_list<P>(path: P) -> Result<Vec<(usize, String)>, Error>
+where
+    P: Into<PathBuf>,
+{
+    let wallets = Accounts::from_dir(path.into())?
         .addresses()
         .iter()
         .enumerate()

--- a/src/list.rs
+++ b/src/list.rs
@@ -13,8 +13,8 @@ pub(crate) fn get_wallets_list(path: &Path) -> Result<Vec<(usize, String)>> {
     Ok(wallets)
 }
 
-pub(crate) fn print_wallet_list(path_opt: Option<String>) -> Result<()> {
-    let path = path_opt.map_or_else(default_vault_path, PathBuf::from);
+pub(crate) fn print_wallet_list(path_opt: Option<PathBuf>) -> Result<()> {
+    let path = path_opt.unwrap_or_else(default_vault_path);
     validate_vault_path(&path)?;
     if !path.exists() {
         bail!("No wallets found in {:?}", path);

--- a/src/list.rs
+++ b/src/list.rs
@@ -1,4 +1,4 @@
-use crate::utils::{handle_vault_path_argument, Accounts};
+use crate::utils::{handle_vault_path, Accounts};
 use crate::Error;
 use std::path::Path;
 
@@ -14,7 +14,7 @@ pub(crate) fn get_wallets_list(path: &Path) -> Result<Vec<(usize, String)>, Erro
 }
 
 pub(crate) fn print_wallet_list(path: Option<String>) -> Result<(), Error> {
-    let vault_path = handle_vault_path_argument(path)?;
+    let vault_path = handle_vault_path(false, path)?;
     if !vault_path.exists() {
         return Err(Error::WalletError(format!(
             "No wallets found at path {:?}",

--- a/src/list.rs
+++ b/src/list.rs
@@ -1,13 +1,10 @@
-use crate::utils::{handle_vault_path, Accounts};
-use crate::Error;
-use std::path::PathBuf;
+use crate::utils::{default_vault_path, validate_vault_path, Accounts};
+use anyhow::{bail, Result};
+use std::path::{Path, PathBuf};
 
 /// Returns index - public address pair for derived accounts
-pub(crate) fn get_wallets_list<P>(path: P) -> Result<Vec<(usize, String)>, Error>
-where
-    P: Into<PathBuf>,
-{
-    let wallets = Accounts::from_dir(path.into())?
+pub(crate) fn get_wallets_list(path: &Path) -> Result<Vec<(usize, String)>> {
+    let wallets = Accounts::from_dir(path)?
         .addresses()
         .iter()
         .enumerate()
@@ -16,15 +13,13 @@ where
     Ok(wallets)
 }
 
-pub(crate) fn print_wallet_list(path: Option<String>) -> Result<(), Error> {
-    let vault_path = handle_vault_path(false, path)?;
-    if !vault_path.exists() {
-        return Err(Error::WalletError(format!(
-            "No wallets found at path {:?}",
-            vault_path
-        )));
+pub(crate) fn print_wallet_list(path_opt: Option<String>) -> Result<()> {
+    let path = path_opt.map_or_else(default_vault_path, PathBuf::from);
+    validate_vault_path(&path)?;
+    if !path.exists() {
+        bail!("No wallets found in {:?}", path);
     }
-    let wallets = get_wallets_list(&vault_path)?;
+    let wallets = get_wallets_list(&path)?;
     println!("#   address\n");
     for wallet in wallets {
         let (index, address) = wallet;

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,8 +8,8 @@ mod utils;
 
 use crate::{
     account::{new_account_cli, print_account_address},
-    export::export_account,
-    import::import_wallet,
+    export::export_account_cli,
+    import::import_wallet_cli,
     init::init_wallet_cli,
     list::print_wallet_list,
     sign::sign_transaction_cli,
@@ -93,11 +93,11 @@ async fn main() -> Result<()> {
             account_index,
             path,
         } => sign_transaction_cli(&id, account_index, path)?,
-        Command::Import { path } => import_wallet(path)?,
+        Command::Import { path } => import_wallet_cli(path)?,
         Command::Export {
             path,
             account_index,
-        } => export_account(path, account_index)?,
+        } => export_account_cli(path, account_index)?,
     };
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,14 +8,14 @@ mod utils;
 
 use crate::{
     account::{new_account, print_account_address},
+    export::export_account,
     import::import_wallet,
-    init::init_wallet,
+    init::init_wallet_cli,
     list::print_wallet_list,
     sign::sign_transaction_cli,
 };
 use anyhow::Result;
 use clap::{ArgEnum, Parser, Subcommand};
-use export::export_account;
 use fuels::prelude::*;
 
 #[derive(Debug, Parser)]
@@ -83,7 +83,7 @@ async fn main() -> Result<()> {
     match app.command {
         Command::New { path } => new_account(path)?,
         Command::List { path } => print_wallet_list(path)?,
-        Command::Init { path } => init_wallet(path)?,
+        Command::Init { path } => init_wallet_cli(path)?,
         Command::Account {
             account_index,
             path,

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use crate::{
     import::import_wallet,
     init::init_wallet,
     list::print_wallet_list,
-    sign::sign_transaction_manually,
+    sign::sign_transaction_cli,
 };
 use anyhow::Result;
 use clap::{ArgEnum, Parser, Subcommand};
@@ -92,7 +92,7 @@ async fn main() -> Result<()> {
             id,
             account_index,
             path,
-        } => sign_transaction_manually(&id, account_index, path).await?,
+        } => sign_transaction_cli(&id, account_index, path)?,
         Command::Import { path } => import_wallet(path)?,
         Command::Export {
             path,

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,8 @@ mod list;
 mod sign;
 mod utils;
 
+use std::path::PathBuf;
+
 use crate::{
     account::{new_account_cli, print_account_address},
     export::export_account_cli,
@@ -35,35 +37,45 @@ struct App {
 #[clap(rename_all = "kebab-case")]
 enum Command {
     /// Generate a new account for the initialized HD wallet.
-    New { path: Option<String> },
+    New {
+        #[clap(long)]
+        path: Option<PathBuf>,
+    },
     /// Initialize the HD wallet from a random mnemonic phrase.
     Init {
         #[clap(long)]
-        path: Option<String>,
+        path: Option<PathBuf>,
     },
     /// Initialize the HD wallet from the provided mnemonic phrase.
     Import {
         #[clap(long)]
-        path: Option<String>,
+        path: Option<PathBuf>,
     },
     /// Lists all accounts derived so far.
-    List { path: Option<String> },
+    List {
+        #[clap(long)]
+        path: Option<PathBuf>,
+    },
     /// Get the address of an acccount from account index
     Account {
+        #[clap(long)]
         account_index: usize,
         #[clap(long)]
-        path: Option<String>,
+        path: Option<PathBuf>,
     },
     /// Sign a transaction by providing its ID and the signing account's index
     Sign {
+        #[clap(long)]
         id: String,
+        #[clap(long)]
         account_index: usize,
-        path: Option<String>,
+        #[clap(long)]
+        path: Option<PathBuf>,
     },
     /// Get the private key of an account from its index
     Export {
         #[clap(long)]
-        path: Option<String>,
+        path: Option<PathBuf>,
         #[clap(long)]
         account_index: usize,
     },

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ mod sign;
 mod utils;
 
 use crate::{
-    account::{new_account, print_account_address},
+    account::{new_account_cli, print_account_address},
     export::export_account,
     import::import_wallet,
     init::init_wallet_cli,
@@ -81,7 +81,7 @@ async fn main() -> Result<()> {
     let app = App::parse();
 
     match app.command {
-        Command::New { path } => new_account(path)?,
+        Command::New { path } => new_account_cli(path)?,
         Command::List { path } => print_wallet_list(path)?,
         Command::Init { path } => init_wallet_cli(path)?,
         Command::Account {

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -5,12 +5,15 @@ use fuel_types::Bytes32;
 use fuels::prelude::*;
 use std::{path::PathBuf, str::FromStr};
 
-fn sign_transaction<P: AsRef<std::path::Path> + std::convert::AsRef<std::ffi::OsStr>>(
+fn sign_transaction<P>(
     tx_id: Bytes32,
     account_index: usize,
     password: &str,
-    path: &P,
-) -> Result<Signature> {
+    path: P,
+) -> Result<Signature>
+where
+    P: Into<PathBuf>,
+{
     let secret_key = derive_account_with_index(path, account_index, password)?;
     let message_hash = unsafe { Message::from_bytes_unchecked(*tx_id) };
     let sig = Signature::sign(&secret_key, &message_hash);

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -15,7 +15,10 @@ pub(crate) async fn sign_transaction_manually(
         None => home::home_dir().unwrap().join(DEFAULT_RELATIVE_VAULT_PATH),
     };
     let tx_id = Bytes32::from_str(id).map_err(|e| anyhow!("{}", e))?;
-    let secret_key = derive_account_with_index(&vault_path, account_index)?;
+    let password = rpassword::prompt_password(
+        "Please enter your password to decrypt initialized wallet's phrases: ",
+    )?;
+    let secret_key = derive_account_with_index(&vault_path, account_index, &password)?;
     let message_hash = unsafe { Message::from_bytes_unchecked(*tx_id) };
     let sig = Signature::sign(&secret_key, &message_hash);
     println!("Signature: {sig}");

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -1,11 +1,23 @@
-use crate::utils::{derive_account_with_index, DEFAULT_RELATIVE_VAULT_PATH};
+use crate::utils::{derive_account_with_index, request_new_password, DEFAULT_RELATIVE_VAULT_PATH};
 use anyhow::{anyhow, Result};
 use fuel_crypto::{Message, Signature};
 use fuel_types::Bytes32;
 use fuels::prelude::*;
 use std::{path::PathBuf, str::FromStr};
 
-pub(crate) async fn sign_transaction_manually(
+fn sign_transaction<P: AsRef<std::path::Path> + std::convert::AsRef<std::ffi::OsStr>>(
+    tx_id: Bytes32,
+    account_index: usize,
+    password: &str,
+    path: &P,
+) -> Result<Signature> {
+    let secret_key = derive_account_with_index(path, account_index, password)?;
+    let message_hash = unsafe { Message::from_bytes_unchecked(*tx_id) };
+    let sig = Signature::sign(&secret_key, &message_hash);
+    Ok(sig)
+}
+
+pub(crate) fn sign_transaction_cli(
     id: &str,
     account_index: usize,
     path: Option<String>,
@@ -14,13 +26,30 @@ pub(crate) async fn sign_transaction_manually(
         Some(path) => PathBuf::from(path),
         None => home::home_dir().unwrap().join(DEFAULT_RELATIVE_VAULT_PATH),
     };
+    let password = request_new_password();
     let tx_id = Bytes32::from_str(id).map_err(|e| anyhow!("{}", e))?;
-    let password = rpassword::prompt_password(
-        "Please enter your password to decrypt initialized wallet's phrases: ",
-    )?;
-    let secret_key = derive_account_with_index(&vault_path, account_index, &password)?;
-    let message_hash = unsafe { Message::from_bytes_unchecked(*tx_id) };
-    let sig = Signature::sign(&secret_key, &message_hash);
-    println!("Signature: {sig}");
+    let signature = sign_transaction(tx_id, account_index, &password, &vault_path)?;
+    println!("Signature: {signature}");
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::utils::test_utils::{save_dummy_wallet_file, with_tmp_folder};
+    use serial_test::serial;
+    #[test]
+    #[serial]
+    fn sign_dummy_transaction() {
+        with_tmp_folder(|tmp_folder| {
+            // initialize a wallet
+            save_dummy_wallet_file(&tmp_folder);
+            let tx_id = Bytes32::from_str(
+                "0x6c226b276bd2028c0582229b6396f91801c913973487491b0262c5c7b3cd6e39",
+            )
+            .unwrap();
+            let sig = sign_transaction(tx_id, 0, "1234", tmp_folder).unwrap();
+            assert_eq!(sig.to_string(), "bcf4651f072130aaf8925610e1d719b76e25b19b0a86779d3f4294964f1607cc95eb6c58eb37bf0510f618bd284decdf936c48ec6722df5472084e4098d54620");
+        });
+    }
 }

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -25,7 +25,7 @@ fn sign_transaction(
 pub(crate) fn sign_transaction_cli(
     id: &str,
     account_index: usize,
-    path_opt: Option<String>,
+    path_opt: Option<PathBuf>,
 ) -> Result<(), Error> {
     let path = path_opt.map_or_else(default_vault_path, PathBuf::from);
     validate_vault_path(&path)?;
@@ -46,7 +46,7 @@ mod tests {
     fn sign_dummy_transaction() {
         with_tmp_folder(|tmp_folder| {
             // initialize a wallet
-            save_dummy_wallet_file(&tmp_folder);
+            save_dummy_wallet_file(tmp_folder);
             let tx_id = Bytes32::from_str(
                 "0x6c226b276bd2028c0582229b6396f91801c913973487491b0262c5c7b3cd6e39",
             )

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -36,7 +36,7 @@ pub(crate) fn sign_transaction_cli(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::utils::test_utils::{save_dummy_wallet_file, with_tmp_folder};
+    use crate::utils::test_utils::{save_dummy_wallet_file, with_tmp_folder, TEST_PASSWORD};
     use serial_test::serial;
     #[test]
     #[serial]
@@ -48,7 +48,7 @@ mod tests {
                 "0x6c226b276bd2028c0582229b6396f91801c913973487491b0262c5c7b3cd6e39",
             )
             .unwrap();
-            let sig = sign_transaction(tx_id, 0, "1234", tmp_folder).unwrap();
+            let sig = sign_transaction(tx_id, 0, TEST_PASSWORD, tmp_folder).unwrap();
             assert_eq!(sig.to_string(), "bcf4651f072130aaf8925610e1d719b76e25b19b0a86779d3f4294964f1607cc95eb6c58eb37bf0510f618bd284decdf936c48ec6722df5472084e4098d54620");
         });
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -185,8 +185,8 @@ mod tests {
 
     #[test]
     fn handle_none_argument() {
-        let path_opt: Option<String> = None;
-        let path = path_opt.map_or_else(default_vault_path, PathBuf::from);
+        let path_opt: Option<PathBuf> = None;
+        let path = path_opt.unwrap_or_else(default_vault_path);
         validate_vault_path(&path).unwrap();
         let home_dir = home_dir().unwrap();
         let default_path = home_dir.join(DEFAULT_RELATIVE_VAULT_PATH);
@@ -197,8 +197,8 @@ mod tests {
     fn handle_relative_path_argument() {
         let home_dir = home_dir().unwrap();
         let test_dir = home_dir.join("forc_wallet_test_dir");
-        let path_opt: Option<String> = test_dir.to_str().map(|path_str| path_str.to_owned());
-        let path = path_opt.map_or_else(default_vault_path, PathBuf::from);
+        let path_opt = Some(test_dir);
+        let path = path_opt.unwrap_or_else(default_vault_path);
         validate_vault_path(&path).unwrap();
         let default_path = home_dir.join("forc_wallet_test_dir");
         assert_eq!(path, default_path)
@@ -206,8 +206,8 @@ mod tests {
 
     #[test]
     fn handle_absolute_path_argument() {
-        let path_opt: Option<String> = Some("forc_wallet_test_dir".to_owned());
-        let path = path_opt.map_or_else(default_vault_path, PathBuf::from);
+        let path_opt: Option<PathBuf> = Some(PathBuf::from("/forc_wallet_test_dir"));
+        let path = path_opt.unwrap_or_else(default_vault_path);
         let path_validation = validate_vault_path(&path).is_err();
         assert!(path_validation)
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -4,9 +4,12 @@ use fuel_crypto::SecretKey;
 use fuels_signers::wallet::DEFAULT_DERIVATION_PATH_PREFIX;
 use home::home_dir;
 use serde::{Deserialize, Serialize};
-use std::io::{Read, Write};
-use std::path::PathBuf;
-use std::{fs, path::Path};
+use std::{
+    fmt::Debug,
+    fs,
+    io::{Read, Write},
+    path::{Path, PathBuf},
+};
 use termion::screen::AlternateScreen;
 
 pub(crate) const DEFAULT_RELATIVE_VAULT_PATH: &str = ".fuel/wallets/";
@@ -82,14 +85,15 @@ where
     }
 }
 
-pub(crate) fn derive_account_with_index<
-    P: AsRef<std::path::Path> + std::convert::AsRef<std::ffi::OsStr>,
->(
-    path: &P,
+pub(crate) fn derive_account_with_index<P>(
+    path: P,
     account_index: usize,
     password: &str,
-) -> Result<SecretKey> {
-    let path_buf = PathBuf::from(path);
+) -> Result<SecretKey>
+where
+    P: Into<PathBuf>,
+{
+    let path_buf = path.into();
     let phrase_recovered = eth_keystore::decrypt_key(path_buf.join(".wallet"), password)?;
     let phrase = String::from_utf8(phrase_recovered)?;
     let derive_path = get_derivation_path(account_index);
@@ -157,11 +161,10 @@ fn handle_vault_path_argument(path: Option<String>) -> Result<PathBuf, Error> {
 }
 
 /// Encrypts and saves the mnemonic phrase to disk
-pub(crate) fn save_phrase_to_disk<P: AsRef<std::path::Path> + std::fmt::Debug>(
-    vault_path: &P,
-    mnemonic: &str,
-    password: &str,
-) {
+pub(crate) fn save_phrase_to_disk<P>(vault_path: &P, mnemonic: &str, password: &str)
+where
+    P: AsRef<Path> + Debug,
+{
     let mnemonic_bytes: Vec<u8> = mnemonic.bytes().collect();
     eth_keystore::encrypt_key(
         &vault_path,


### PR DESCRIPTION
This PR adds tests for basic wallet functionalities that we have now. To do so I needed to separate CLI and actual logic so that I could add tests for the logic. Also I tried to refactor the code such for passing around `Path` to the logic functions, ~I used `AsRef<Path>` so that if we decide to consume this crate as a lib for `forc-client` etc, API is as accepting as possible~.


I needed serial tests as for the tests I am generating and removing a tmp directory. Since by default `cargo test` works in parallel, different tests can remove the folder created for other tests. To overcome this I can either run the tests in parallel but create different directories for each test or the tests that needs a tmp dir will need to work serially. Since tests are pretty quick I followed the serial tests path to reduce required I/O operations during the tests but I am open to other way as well.

closes #10.
closes #56.