### PR TITLE
import is own command and not anymore a argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@ forc-wallet init
 
 This will require a password for encyrpting the wallet. After the initialization is done you will be given the mnemonic phrase of the wallet.
 
-You can also initialize a wallet with your existing mnemonic phrase by passing `--import` to
-`forc-wallet init`.
+You can also initialize a wallet with your existing mnemonic phrase by using `forc-wallet import`.
 
 ### Create an account
 


### PR DESCRIPTION
In commit 217c466 the import argument was moved to a separate command, the current README does not reflect that.