### PR TITLE
chore: clippy warnings for rust 1.66.1

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -222,7 +222,7 @@ mod tests {
         with_tmp_folder(|tmp_folder| {
             save_phrase_to_disk(tmp_folder, TEST_MNEMONIC, TEST_PASSWORD);
             let phrase_recovered =
-                eth_keystore::decrypt_key(&tmp_folder.join(".wallet"), TEST_PASSWORD).unwrap();
+                eth_keystore::decrypt_key(tmp_folder.join(".wallet"), TEST_PASSWORD).unwrap();
             let phrase = String::from_utf8(phrase_recovered).unwrap();
             assert_eq!(phrase, TEST_MNEMONIC)
         });


### PR DESCRIPTION
- Removed needless borrow in one place so that CI would still pass for branches forked from master