### PR TITLE
Refactor `--path` arg for commands, use consistent terminology for wallet directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ forc-wallet list
 To retrieve the address of a specific account, you can use:
 
 ```sh
-forc-wallet account --account-index <account_index>
+forc-wallet account --index <account_index>
 ```
 
 ### Get private key of an account

--- a/src/account.rs
+++ b/src/account.rs
@@ -1,6 +1,6 @@
 use crate::utils::{
     create_accounts_file, default_wallet_path, get_derivation_path, number_of_derived_accounts,
-    validate_vault_path, Accounts,
+    validate_wallet_path, Accounts,
 };
 use anyhow::{bail, Result};
 use fuels::prelude::WalletUnlocked;
@@ -8,7 +8,7 @@ use std::path::{Path, PathBuf};
 
 pub(crate) fn print_account_address(path_opt: Option<PathBuf>, account_index: usize) -> Result<()> {
     let path = path_opt.unwrap_or_else(default_wallet_path);
-    validate_vault_path(&path)?;
+    validate_wallet_path(&path)?;
     let existing_accounts = Accounts::from_dir(&path)?;
     if let Some(account) = existing_accounts.addresses().iter().nth(account_index) {
         println!("Account {account_index} address: {account}");
@@ -32,7 +32,7 @@ fn new_account(vault_path: &Path, password: &str) -> Result<WalletUnlocked> {
 
 pub(crate) fn new_account_cli(path_opt: Option<PathBuf>) -> Result<()> {
     let path = path_opt.unwrap_or_else(default_wallet_path);
-    validate_vault_path(&path)?;
+    validate_wallet_path(&path)?;
     let existing_accounts = Accounts::from_dir(&path)?;
     if !path.join(".wallet").exists() {
         bail!("Wallet is not initialized, please initialize a wallet before creating an account! To initialize a wallet: \"forc-wallet init\"");

--- a/src/account.rs
+++ b/src/account.rs
@@ -1,6 +1,6 @@
 use crate::utils::{
     create_accounts_file, default_wallet_path, get_derivation_path, number_of_derived_accounts,
-    validate_wallet_path, Accounts,
+    validate_wallet_path, wallet_keystore_path, Accounts,
 };
 use anyhow::{bail, Result};
 use fuels::prelude::WalletUnlocked;
@@ -18,13 +18,12 @@ pub(crate) fn print_account_address(path_opt: Option<PathBuf>, account_index: us
     Ok(())
 }
 
-fn new_account(vault_path: &Path, password: &str) -> Result<WalletUnlocked> {
-    let vault_path_buf = PathBuf::from(vault_path);
-    let account_index = number_of_derived_accounts(&vault_path_buf);
+fn new_account(wallet_dir: &Path, password: &str) -> Result<WalletUnlocked> {
+    let account_index = number_of_derived_accounts(wallet_dir);
     println!("Generating account with index: {account_index}");
     let derive_path = get_derivation_path(account_index);
-
-    let phrase_recovered = eth_keystore::decrypt_key(vault_path_buf.join(".wallet"), password)?;
+    let wallet_keystore_path = wallet_keystore_path(wallet_dir);
+    let phrase_recovered = eth_keystore::decrypt_key(&wallet_keystore_path, password)?;
     let phrase = String::from_utf8(phrase_recovered)?;
     let wallet = WalletUnlocked::new_from_mnemonic_phrase_with_path(&phrase, None, &derive_path)?;
     Ok(wallet)

--- a/src/account.rs
+++ b/src/account.rs
@@ -23,7 +23,7 @@ fn new_account(wallet_dir: &Path, password: &str) -> Result<WalletUnlocked> {
     println!("Generating account with index: {account_index}");
     let derive_path = get_derivation_path(account_index);
     let wallet_keystore_path = wallet_keystore_path(wallet_dir);
-    let phrase_recovered = eth_keystore::decrypt_key(&wallet_keystore_path, password)?;
+    let phrase_recovered = eth_keystore::decrypt_key(wallet_keystore_path, password)?;
     let phrase = String::from_utf8(phrase_recovered)?;
     let wallet = WalletUnlocked::new_from_mnemonic_phrase_with_path(&phrase, None, &derive_path)?;
     Ok(wallet)

--- a/src/account.rs
+++ b/src/account.rs
@@ -1,5 +1,5 @@
 use crate::utils::{
-    create_accounts_file, default_vault_path, get_derivation_path, number_of_derived_accounts,
+    create_accounts_file, default_wallet_path, get_derivation_path, number_of_derived_accounts,
     validate_vault_path, Accounts,
 };
 use anyhow::{bail, Result};
@@ -7,7 +7,7 @@ use fuels::prelude::WalletUnlocked;
 use std::path::{Path, PathBuf};
 
 pub(crate) fn print_account_address(path_opt: Option<PathBuf>, account_index: usize) -> Result<()> {
-    let path = path_opt.unwrap_or_else(default_vault_path);
+    let path = path_opt.unwrap_or_else(default_wallet_path);
     validate_vault_path(&path)?;
     let existing_accounts = Accounts::from_dir(&path)?;
     if let Some(account) = existing_accounts.addresses().iter().nth(account_index) {
@@ -31,7 +31,7 @@ fn new_account(vault_path: &Path, password: &str) -> Result<WalletUnlocked> {
 }
 
 pub(crate) fn new_account_cli(path_opt: Option<PathBuf>) -> Result<()> {
-    let path = path_opt.unwrap_or_else(default_vault_path);
+    let path = path_opt.unwrap_or_else(default_wallet_path);
     validate_vault_path(&path)?;
     let existing_accounts = Accounts::from_dir(&path)?;
     if !path.join(".wallet").exists() {

--- a/src/export.rs
+++ b/src/export.rs
@@ -1,13 +1,12 @@
-use std::path::PathBuf;
-
 use crate::utils::{
-    default_wallet_path, derive_account_with_index, display_string_discreetly, validate_vault_path,
+    default_wallet_path, derive_account_with_index, display_string_discreetly, validate_wallet_path,
 };
 use anyhow::Result;
+use std::path::PathBuf;
 
 pub(crate) fn export_account_cli(path_opt: Option<PathBuf>, account_index: usize) -> Result<()> {
     let path = path_opt.unwrap_or_else(default_wallet_path);
-    validate_vault_path(&path)?;
+    validate_wallet_path(&path)?;
 
     let password = rpassword::prompt_password(
         "Please enter your password to decrypt initialized wallet's phrases: ",

--- a/src/export.rs
+++ b/src/export.rs
@@ -1,12 +1,12 @@
 use std::path::PathBuf;
 
 use crate::utils::{
-    default_vault_path, derive_account_with_index, display_string_discreetly, validate_vault_path,
+    default_wallet_path, derive_account_with_index, display_string_discreetly, validate_vault_path,
 };
 use anyhow::Result;
 
 pub(crate) fn export_account_cli(path_opt: Option<PathBuf>, account_index: usize) -> Result<()> {
-    let path = path_opt.unwrap_or_else(default_vault_path);
+    let path = path_opt.unwrap_or_else(default_wallet_path);
     validate_vault_path(&path)?;
 
     let password = rpassword::prompt_password(

--- a/src/import.rs
+++ b/src/import.rs
@@ -1,5 +1,5 @@
 use crate::utils::{
-    default_vault_path, request_new_password, save_phrase_to_disk, validate_vault_path,
+    default_wallet_path, request_new_password, save_phrase_to_disk, validate_vault_path,
 };
 use anyhow::{bail, Result};
 use fuels::signers::wallet::WalletUnlocked;
@@ -15,7 +15,7 @@ fn check_mnemonic(mnemonic: &str) -> Result<()> {
 }
 
 pub(crate) fn import_wallet_cli(path_opt: Option<PathBuf>) -> Result<()> {
-    let path = path_opt.unwrap_or_else(default_vault_path);
+    let path = path_opt.unwrap_or_else(default_wallet_path);
     validate_vault_path(&path)?;
     let mnemonic = rpassword::prompt_password("Please enter your mnemonic phrase: ")?;
     check_mnemonic(&mnemonic)?;

--- a/src/import.rs
+++ b/src/import.rs
@@ -1,5 +1,5 @@
 use crate::utils::{
-    default_wallet_path, request_new_password, save_phrase_to_disk, validate_vault_path,
+    default_wallet_path, request_new_password, save_phrase_to_disk, validate_wallet_path,
 };
 use anyhow::{bail, Result};
 use fuels::signers::wallet::WalletUnlocked;
@@ -16,7 +16,7 @@ fn check_mnemonic(mnemonic: &str) -> Result<()> {
 
 pub(crate) fn import_wallet_cli(path_opt: Option<PathBuf>) -> Result<()> {
     let path = path_opt.unwrap_or_else(default_wallet_path);
-    validate_vault_path(&path)?;
+    validate_wallet_path(&path)?;
     let mnemonic = rpassword::prompt_password("Please enter your mnemonic phrase: ")?;
     check_mnemonic(&mnemonic)?;
     let password = request_new_password();

--- a/src/init.rs
+++ b/src/init.rs
@@ -1,6 +1,6 @@
 use crate::{
     utils::{
-        create_vault, default_wallet_path, display_string_discreetly, request_new_password,
+        create_wallet, default_wallet_path, display_string_discreetly, request_new_password,
         save_phrase_to_disk, validate_wallet_path,
     },
     Error,
@@ -19,7 +19,7 @@ fn init_wallet(path: &Path, password: &str) -> Result<String, Error> {
 pub(crate) fn init_wallet_cli(path_opt: Option<PathBuf>) -> Result<(), Error> {
     let path = path_opt.unwrap_or_else(default_wallet_path);
     validate_wallet_path(&path)?;
-    create_vault(&path)?;
+    create_wallet(&path)?;
     let password = request_new_password();
     let mnemonic = init_wallet(&path, &password)?;
     let mnemonic_string = format!("Wallet mnemonic phrase: {mnemonic}\n");

--- a/src/init.rs
+++ b/src/init.rs
@@ -1,7 +1,7 @@
 use crate::{
     utils::{
         create_vault, default_wallet_path, display_string_discreetly, request_new_password,
-        save_phrase_to_disk, validate_vault_path,
+        save_phrase_to_disk, validate_wallet_path,
     },
     Error,
 };
@@ -18,7 +18,7 @@ fn init_wallet(path: &Path, password: &str) -> Result<String, Error> {
 
 pub(crate) fn init_wallet_cli(path_opt: Option<PathBuf>) -> Result<(), Error> {
     let path = path_opt.unwrap_or_else(default_wallet_path);
-    validate_vault_path(&path)?;
+    validate_wallet_path(&path)?;
     create_vault(&path)?;
     let password = request_new_password();
     let mnemonic = init_wallet(&path, &password)?;

--- a/src/init.rs
+++ b/src/init.rs
@@ -1,6 +1,6 @@
 use crate::{
     utils::{
-        create_vault, default_vault_path, display_string_discreetly, request_new_password,
+        create_vault, default_wallet_path, display_string_discreetly, request_new_password,
         save_phrase_to_disk, validate_vault_path,
     },
     Error,
@@ -17,7 +17,7 @@ fn init_wallet(path: &Path, password: &str) -> Result<String, Error> {
 }
 
 pub(crate) fn init_wallet_cli(path_opt: Option<PathBuf>) -> Result<(), Error> {
-    let path = path_opt.unwrap_or_else(default_vault_path);
+    let path = path_opt.unwrap_or_else(default_wallet_path);
     validate_vault_path(&path)?;
     create_vault(&path)?;
     let password = request_new_password();

--- a/src/list.rs
+++ b/src/list.rs
@@ -1,4 +1,4 @@
-use crate::utils::{default_vault_path, validate_vault_path, Accounts};
+use crate::utils::{default_wallet_path, validate_vault_path, Accounts};
 use anyhow::{bail, Result};
 use std::path::{Path, PathBuf};
 
@@ -14,7 +14,7 @@ pub(crate) fn get_wallets_list(path: &Path) -> Result<Vec<(usize, String)>> {
 }
 
 pub(crate) fn print_wallet_list(path_opt: Option<PathBuf>) -> Result<()> {
-    let path = path_opt.unwrap_or_else(default_vault_path);
+    let path = path_opt.unwrap_or_else(default_wallet_path);
     validate_vault_path(&path)?;
     if !path.exists() {
         bail!("No wallets found in {:?}", path);

--- a/src/list.rs
+++ b/src/list.rs
@@ -1,4 +1,4 @@
-use crate::utils::{default_wallet_path, validate_vault_path, Accounts};
+use crate::utils::{default_wallet_path, validate_wallet_path, Accounts};
 use anyhow::{bail, Result};
 use std::path::{Path, PathBuf};
 
@@ -15,7 +15,7 @@ pub(crate) fn get_wallets_list(path: &Path) -> Result<Vec<(usize, String)>> {
 
 pub(crate) fn print_wallet_list(path_opt: Option<PathBuf>) -> Result<()> {
     let path = path_opt.unwrap_or_else(default_wallet_path);
-    validate_vault_path(&path)?;
+    validate_wallet_path(&path)?;
     if !path.exists() {
         bail!("No wallets found in {:?}", path);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ struct App {
     /// JSON keystore file. It may also contain an `.accounts` JSON file
     /// containing a list of accounts that have been known to be derived so
     /// far.
-    /// By default, this is `$HOME/.fuel/wallets/default`.
+    /// By default, this is `$HOME/.fuel/wallets`.
     #[clap(long = "path")]
     wallet_path: Option<PathBuf>,
     #[clap(subcommand)]

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -1,5 +1,5 @@
 use crate::utils::{
-    default_vault_path, derive_account_with_index, request_new_password, validate_vault_path,
+    default_wallet_path, derive_account_with_index, request_new_password, validate_vault_path,
 };
 use anyhow::{anyhow, Result};
 use fuel_crypto::{Message, SecretKey, Signature};
@@ -40,7 +40,7 @@ pub(crate) fn sign_transaction_cli(
     account_index: usize,
     path_opt: Option<PathBuf>,
 ) -> Result<(), Error> {
-    let path = path_opt.map_or_else(default_vault_path, PathBuf::from);
+    let path = path_opt.map_or_else(default_wallet_path, PathBuf::from);
     validate_vault_path(&path)?;
     let password = request_new_password();
     let tx_id = Bytes32::from_str(id).map_err(|e| anyhow!("{}", e))?;

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -1,5 +1,5 @@
 use crate::utils::{
-    default_wallet_path, derive_account_with_index, request_new_password, validate_vault_path,
+    default_wallet_path, derive_account_with_index, request_new_password, validate_wallet_path,
 };
 use anyhow::{anyhow, Result};
 use fuel_crypto::{Message, SecretKey, Signature};
@@ -41,7 +41,7 @@ pub(crate) fn sign_transaction_cli(
     path_opt: Option<PathBuf>,
 ) -> Result<(), Error> {
     let path = path_opt.map_or_else(default_wallet_path, PathBuf::from);
-    validate_vault_path(&path)?;
+    validate_wallet_path(&path)?;
     let password = request_new_password();
     let tx_id = Bytes32::from_str(id).map_err(|e| anyhow!("{}", e))?;
     let signature = sign_transaction(tx_id, account_index, &password, &path)?;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -15,8 +15,6 @@ use termion::screen::AlternateScreen;
 const USER_FUEL_DIR: &str = ".fuel";
 /// The directory under which `forc wallet` generates wallets.
 const WALLETS_DIR: &str = "wallets";
-/// The directory of the default wallet when no wallet path is specified.
-const DEFAULT_WALLET_DIR: &str = "default";
 /// The file stem for the wallet file, a JSON file with AES encrypted keys etc.
 const WALLET_FILE_STEM: &str = ".wallet";
 /// The file storing wallet account information.
@@ -82,10 +80,7 @@ pub(crate) fn validate_wallet_path(path: &Path) -> Result<()> {
 /// Returns default wallet directory which is `$HOME/.fuel/wallets/default`.
 pub(crate) fn default_wallet_path() -> PathBuf {
     let home_dir = home_dir().expect("Cannot get home directory!");
-    home_dir
-        .join(USER_FUEL_DIR)
-        .join(WALLETS_DIR)
-        .join(DEFAULT_WALLET_DIR)
+    home_dir.join(USER_FUEL_DIR).join(WALLETS_DIR)
 }
 
 /// Returns the number of the accounts derived so far by reading the .accounts file from given path

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -68,7 +68,7 @@ pub(crate) fn create_vault(path: &Path) -> Result<()> {
 }
 
 /// If the path is not relative to the home directory, error out.
-pub(crate) fn validate_vault_path(path: &Path) -> Result<()> {
+pub(crate) fn validate_wallet_path(path: &Path) -> Result<()> {
     let home_dir = home_dir().ok_or_else(|| anyhow!("Cannot get home directory!"))?;
     if !path.starts_with(home_dir) {
         bail!(
@@ -202,7 +202,7 @@ mod tests {
     fn handle_none_argument() {
         let path_opt: Option<PathBuf> = None;
         let path = path_opt.unwrap_or_else(default_wallet_path);
-        validate_vault_path(&path).unwrap();
+        validate_wallet_path(&path).unwrap();
         let default_path = default_wallet_path();
         assert_eq!(path, default_path)
     }
@@ -213,7 +213,7 @@ mod tests {
         let test_dir = home_dir.join("forc_wallet_test_dir");
         let path_opt = Some(test_dir);
         let path = path_opt.unwrap_or_else(default_wallet_path);
-        validate_vault_path(&path).unwrap();
+        validate_wallet_path(&path).unwrap();
         let default_path = home_dir.join("forc_wallet_test_dir");
         assert_eq!(path, default_path)
     }
@@ -222,7 +222,7 @@ mod tests {
     fn handle_absolute_path_argument() {
         let path_opt: Option<PathBuf> = Some(PathBuf::from("/forc_wallet_test_dir"));
         let path = path_opt.unwrap_or_else(default_wallet_path);
-        let path_validation = validate_vault_path(&path).is_err();
+        let path_validation = validate_wallet_path(&path).is_err();
         assert!(path_validation)
     }
     #[test]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -57,8 +57,8 @@ pub(crate) fn create_accounts_file(wallet_dir: &Path, accounts: Vec<String>) -> 
     Ok(())
 }
 
-/// Creates the wallet vault if it does not exists.
-pub(crate) fn create_vault(path: &Path) -> Result<()> {
+/// Creates the wallet directory at the given path if it does not exist.
+pub(crate) fn create_wallet(path: &Path) -> Result<()> {
     if path.exists() {
         bail!(format!("Cannot import wallet at {path:?}, the directory already exists! You can clear the given path and re-use the same path"))
     } else {
@@ -179,22 +179,22 @@ mod tests {
 
     #[test]
     #[serial]
-    fn create_vault_should_success() {
+    fn create_wallet_should_success() {
         with_tmp_folder(|tmp_folder| {
             let test_vault_path = tmp_folder.join("handle_vault_path_success_dir");
-            let create_vault_status = create_vault(&test_vault_path).is_ok();
-            assert!(create_vault_status)
+            let create_wallet_status = create_wallet(&test_vault_path).is_ok();
+            assert!(create_wallet_status)
         });
     }
 
     #[test]
     #[serial]
-    fn create_vault_should_fail() {
+    fn create_wallet_should_fail() {
         with_tmp_folder(|tmp_folder| {
             let test_vault_path = tmp_folder.join("handle_vault_path_fail_dir");
             std::fs::create_dir_all(&test_vault_path).unwrap();
-            let create_vault_status = create_vault(&test_vault_path).is_err();
-            assert!(create_vault_status)
+            let create_wallet_status = create_wallet(&test_vault_path).is_err();
+            assert!(create_wallet_status)
         });
     }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -98,7 +98,7 @@ pub(crate) fn number_of_derived_accounts(path: &Path) -> usize {
     }
 }
 
-fn wallet_keystore_path(wallet_dir: &Path) -> PathBuf {
+pub(crate) fn wallet_keystore_path(wallet_dir: &Path) -> PathBuf {
     wallet_dir.join(WALLET_FILE_STEM)
 }
 
@@ -157,16 +157,16 @@ pub(crate) fn display_string_discreetly(
 }
 
 /// Encrypts and saves the mnemonic phrase to disk
-pub(crate) fn save_phrase_to_disk(vault_path: &Path, mnemonic: &str, password: &str) {
+pub(crate) fn save_phrase_to_disk(wallet_dir: &Path, mnemonic: &str, password: &str) {
     let mnemonic_bytes: Vec<u8> = mnemonic.bytes().collect();
     eth_keystore::encrypt_key(
-        vault_path,
+        wallet_dir,
         &mut rand::thread_rng(),
         mnemonic_bytes,
         password,
         Some(WALLET_FILE_STEM),
     )
-    .unwrap_or_else(|error| panic!("Cannot create eth_keystore at {vault_path:?}: {error:?}"));
+    .unwrap_or_else(|error| panic!("Cannot create eth_keystore at {wallet_dir:?}: {error:?}"));
 }
 
 #[cfg(test)]
@@ -181,8 +181,8 @@ mod tests {
     #[serial]
     fn create_wallet_should_success() {
         with_tmp_folder(|tmp_folder| {
-            let test_vault_path = tmp_folder.join("handle_vault_path_success_dir");
-            let create_wallet_status = create_wallet(&test_vault_path).is_ok();
+            let test_wallet_dir = tmp_folder.join("handle_wallet_dir_success_dir");
+            let create_wallet_status = create_wallet(&test_wallet_dir).is_ok();
             assert!(create_wallet_status)
         });
     }
@@ -191,9 +191,9 @@ mod tests {
     #[serial]
     fn create_wallet_should_fail() {
         with_tmp_folder(|tmp_folder| {
-            let test_vault_path = tmp_folder.join("handle_vault_path_fail_dir");
-            std::fs::create_dir_all(&test_vault_path).unwrap();
-            let create_wallet_status = create_wallet(&test_vault_path).is_err();
+            let test_wallet_dir = tmp_folder.join("handle_wallet_dir_fail_dir");
+            std::fs::create_dir_all(&test_wallet_dir).unwrap();
+            let create_wallet_status = create_wallet(&test_wallet_dir).is_err();
             assert!(create_wallet_status)
         });
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -11,7 +11,7 @@ use std::{
 };
 use termion::screen::AlternateScreen;
 
-pub(crate) const DEFAULT_RELATIVE_VAULT_PATH: &str = ".fuel/wallets/";
+const USER_FUEL_DIR: &str = ".fuel";
 
 #[derive(Serialize, Deserialize)]
 pub(crate) struct Accounts {
@@ -72,8 +72,9 @@ pub(crate) fn validate_vault_path(path: &Path) -> Result<()> {
 
 /// Returns default vault path which is $HOME/.fuel/wallets
 pub(crate) fn default_vault_path() -> PathBuf {
+    const WALLETS_DIR: &str = "wallets";
     let home_dir = home_dir().expect("Cannot get home directory!");
-    home_dir.join(DEFAULT_RELATIVE_VAULT_PATH)
+    home_dir.join(USER_FUEL_DIR).join(WALLETS_DIR)
 }
 
 /// Returns the number of the accounts derived so far by reading the .accounts file from given path
@@ -183,8 +184,7 @@ mod tests {
         let path_opt: Option<PathBuf> = None;
         let path = path_opt.unwrap_or_else(default_vault_path);
         validate_vault_path(&path).unwrap();
-        let home_dir = home_dir().unwrap();
-        let default_path = home_dir.join(DEFAULT_RELATIVE_VAULT_PATH);
+        let default_path = default_vault_path();
         assert_eq!(path, default_path)
     }
 


### PR DESCRIPTION
Closes #76.

## `--path` arg

Previously each subcommand had it's own instance of the `--path` argument. Instead, we now expect the `--path` argument on the top-level command, e.g.

```console
forc wallet --path ./path/to/wallet list
```
rather than
```console
forc wallet list --path ./path/to/wallet
```
By coupling the arg with the `wallet` command we also make the association a bit clearer.

## Wallet vs Vault

This PR also refactors a lot of the utility functions to use "wallet" when referring to the wallet directory, rather than "vault". Before, the two were used interchangeably which could cause some confusion for future maintainers.