### PR TITLE
Add `--unverified` option to commands that display cached addresses

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,9 @@ mod sign;
 mod utils;
 
 use crate::{
-    account::Account, import::import_wallet_cli, new::new_wallet_cli,
+    account::{Account, Accounts},
+    import::import_wallet_cli,
+    new::new_wallet_cli,
     sign::sign_transaction_with_private_key_cli,
 };
 use anyhow::Result;
@@ -43,7 +45,12 @@ enum Command {
     /// *locally* and still exist within the user's `~/.fuel/wallets/accoutns`
     /// cache. If this wallet was recently imported, you may need to re-derive
     /// your accounts.
-    Accounts,
+    ///
+    /// By default, this requires your password in order to verify and re-
+    /// derive each of the accounts. Use the `--unverified` flag to bypass
+    /// this password check and read the public addresses directly from the
+    /// `~/.fuel/wallets/accounts` cache.
+    Accounts(Accounts),
     /// Derive a new account, sign with an existing account, or display an
     /// account's public or private key. See the `EXAMPLES` below.
     Account(Account),
@@ -94,7 +101,7 @@ async fn main() -> Result<()> {
     match app.cmd {
         Command::New => new_wallet_cli(&wallet_path)?,
         Command::Import => import_wallet_cli(&wallet_path)?,
-        Command::Accounts => account::print_accounts_cli(&wallet_path)?,
+        Command::Accounts(accounts) => account::print_accounts_cli(&wallet_path, accounts)?,
         Command::Account(account) => account::cli(&wallet_path, account)?,
         Command::SignPrivate(SignCmd::Tx { tx_id }) => {
             sign_transaction_with_private_key_cli(tx_id)?


### PR DESCRIPTION
*PR based on #84.*

Closes #77 as the main concern with storing addresses in plain text is that it makes them an easy target of corruption.

This PR changes the behaviour of the `forc wallet accounts` and `forc wallet account <ix>` commands to always require a password by default. This ensures the printed addresses are valid. This was tricky to guarantee in the old behaviour as the cached plain-text files could have been corrupted or maliciously altered since they were last written.

Both commands now accept an `--unverified` flag that emulates the old behaviour and purely reads the addresses from the cache.