### PR TITLE
feat: Add support for signing arbitrary data via new `string`, `file` or `hex` subcommands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -944,6 +944,7 @@ dependencies = [
  "fuel-types",
  "fuels",
  "fuels-signers",
+ "hex",
  "home",
  "rand",
  "rpassword",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ fuel-crypto = "0.26"
 fuel-types = "0.26"
 fuels = { version = "0.36.0", default-features = false }
 fuels-signers = "0.36.0"
+hex = "0.4"
 home = "0.5.3"
 rand = { version = "0.8.4", default-features = false }
 rpassword = "7.2"

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ forc-wallet sign --account <account_index> hex 0123456789ABCDEF
 Using the `sign` subcommand, you can choose to sign directly with a private key (rather than a wallet account):
 
 ```sh
-forc-wallet sign --private hex 0123456789ABCDEF
+forc-wallet sign --private-key hex 0123456789ABCDEF
 ```
 
 ## Other useful commands

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ forc-wallet accounts
 
 ### Sign a transaction
 
-To sign a transaction, you can do so with its ID. You can generate a transaction and get its ID using `forc-client`. Signing the transaction once you have the ID is simple:
+To sign a transaction, you can provide the transaction ID. You can generate a transaction and get its ID using `forc-client`. Signing the transaction once you have the ID is simple:
 
 ```sh
 forc-wallet account <account_index> sign tx-id <transaction_id>

--- a/README.md
+++ b/README.md
@@ -72,10 +72,48 @@ forc-wallet accounts
 
 ### Sign a transaction
 
-To sign a transaction, you must provide the transaction ID. You can generate a transaction and get its ID using `forc-client`. Signing the transaction once you have the ID is simple:
+To sign a transaction, you can do so with its ID. You can generate a transaction and get its ID using `forc-client`. Signing the transaction once you have the ID is simple:
 
 ```sh
-forc-wallet account <account_index> sign tx <transaction_id>
+forc-wallet account <account_index> sign tx-id <transaction_id>
+```
+
+### Sign arbitrary data
+
+You may sign a string directly:
+
+```sh
+forc-wallet account <account_index> sign string "Blah blah blah"
+```
+
+Or the contents of a file:
+
+```sh
+forc-wallet account <account_index> sign file <path>
+```
+
+You may also sign a hex-encoded byte string:
+
+```sh
+forc-wallet account <account_index> sign hex 0x0123456789ABCDEF
+```
+
+The hex prefix at the beginning of the string is optional, e.g. the following is the same as above:
+
+```sh
+forc-wallet account <account_index> sign hex 0123456789ABCDEF
+```
+
+You can also use the `sign` subcommand directly, e.g. the following is the same:
+
+```sh
+forc-wallet sign --account <account_index> hex 0123456789ABCDEF
+```
+
+Using the `sign` subcommand, you can choose to sign directly with a private key (rather than a wallet account):
+
+```sh
+forc-wallet sign --private hex 0123456789ABCDEF
 ```
 
 ## Other useful commands

--- a/src/account.rs
+++ b/src/account.rs
@@ -44,7 +44,7 @@ pub(crate) enum Command {
     New,
     /// Sign a transaction with the specified account.
     #[clap(subcommand)]
-    Sign(sign::Command),
+    Sign(sign::Data),
     /// Temporarily display the private key of an account from its index.
     ///
     /// WARNING: This prints your account's private key to an alternative,
@@ -68,7 +68,9 @@ pub(crate) fn cli(wallet_path: &Path, account: Account) -> Result<()> {
         (None, Some(Command::New)) => new_cli(wallet_path)?,
         (Some(acc_ix), Some(Command::New)) => new_at_index_cli(wallet_path, acc_ix)?,
         (Some(acc_ix), None) => print_address(wallet_path, acc_ix, account.unverified.unverified)?,
-        (Some(acc_ix), Some(Command::Sign(sign_cmd))) => sign::cli(wallet_path, acc_ix, sign_cmd)?,
+        (Some(acc_ix), Some(Command::Sign(sign_cmd))) => {
+            sign::wallet_account_cli(wallet_path, acc_ix, sign_cmd)?
+        }
         (Some(acc_ix), Some(Command::PrivateKey)) => private_key_cli(wallet_path, acc_ix)?,
         (None, Some(cmd)) => print_subcmd_index_warning(&cmd),
         (None, None) => print_subcmd_help(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ use crate::{
     account::{Account, Accounts},
     import::import_wallet_cli,
     new::new_wallet_cli,
+    sign::Sign,
 };
 use anyhow::Result;
 use clap::{Parser, Subcommand};
@@ -53,10 +54,7 @@ enum Command {
     /// Derive a new account, sign with an existing account, or display an
     /// account's public or private key. See the `EXAMPLES` below.
     Account(Account),
-    /// Sign something by providing a private key *directly*, rather than with
-    /// a wallet account.
-    #[clap(subcommand)]
-    SignPrivate(sign::Command),
+    Sign(Sign),
 }
 
 const ABOUT: &str = "A forc plugin for generating or importing wallets using BIP39 phrases.";
@@ -77,8 +75,23 @@ EXAMPLES:
     # Derive (or re-derive) the account at index 5.
     forc wallet account 5 new
 
-    # Sign a transaction via its ID with account at index 3.
+    # Sign a transaction ID with account at index 3.
     forc wallet account 3 sign tx-id 0x0bf34feb362608c4171c87115d4a6f63d1cdf4c49b963b464762329488f3ed4f
+
+    # Sign an arbitrary string.
+    forc wallet account 3 sign string "blah blah blah"
+
+    # Sign the contents of a file.
+    forc wallet account 3 sign file /path/to/data-to-sign
+
+    # Sign a hex-encoded byte string.
+    forc wallet account 3 sign hex "0xDEADBEEF"
+
+    # You can also use the `sign` subcommand directly. The following gives the same result.
+    forc wallet sign --account 3 string "blah blah blah"
+
+    # Sign directly with a private key.
+    forc wallet sign --private string "blah blah blah"
 
     # Temporarily display the private key of the account at index 0.
     forc wallet account 0 private-key
@@ -93,7 +106,7 @@ async fn main() -> Result<()> {
         Command::Import => import_wallet_cli(&wallet_path)?,
         Command::Accounts(accounts) => account::print_accounts_cli(&wallet_path, accounts)?,
         Command::Account(account) => account::cli(&wallet_path, account)?,
-        Command::SignPrivate(sign_cmd) => sign::private_key_cli(sign_cmd)?,
+        Command::Sign(sign) => sign::cli(&wallet_path, sign)?,
     }
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,6 @@ use crate::{
     account::{Account, Accounts},
     import::import_wallet_cli,
     new::new_wallet_cli,
-    sign::sign_transaction_with_private_key_cli,
 };
 use anyhow::Result;
 use clap::{Parser, Subcommand};
@@ -57,16 +56,7 @@ enum Command {
     /// Sign something by providing a private key *directly*, rather than with
     /// a wallet account.
     #[clap(subcommand)]
-    SignPrivate(SignCmd),
-}
-
-#[derive(Debug, Subcommand)]
-enum SignCmd {
-    /// Sign a transaction given it's ID.
-    Tx {
-        /// The transaction ID.
-        tx_id: fuel_types::Bytes32,
-    },
+    SignPrivate(sign::Command),
 }
 
 const ABOUT: &str = "A forc plugin for generating or importing wallets using BIP39 phrases.";
@@ -88,7 +78,7 @@ EXAMPLES:
     forc wallet account 5 new
 
     # Sign a transaction via its ID with account at index 3.
-    forc wallet account 3 sign tx 0x0bf34feb362608c4171c87115d4a6f63d1cdf4c49b963b464762329488f3ed4f
+    forc wallet account 3 sign tx-id 0x0bf34feb362608c4171c87115d4a6f63d1cdf4c49b963b464762329488f3ed4f
 
     # Temporarily display the private key of the account at index 0.
     forc wallet account 0 private-key
@@ -103,9 +93,7 @@ async fn main() -> Result<()> {
         Command::Import => import_wallet_cli(&wallet_path)?,
         Command::Accounts(accounts) => account::print_accounts_cli(&wallet_path, accounts)?,
         Command::Account(account) => account::cli(&wallet_path, account)?,
-        Command::SignPrivate(SignCmd::Tx { tx_id }) => {
-            sign_transaction_with_private_key_cli(tx_id)?
-        }
+        Command::SignPrivate(sign_cmd) => sign::private_key_cli(sign_cmd)?,
     }
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,7 +91,7 @@ EXAMPLES:
     forc wallet sign --account 3 string "blah blah blah"
 
     # Sign directly with a private key.
-    forc wallet sign --private string "blah blah blah"
+    forc wallet sign --private-key string "blah blah blah"
 
     # Temporarily display the private key of the account at index 0.
     forc wallet account 0 private-key

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -1,61 +1,179 @@
 use crate::account;
-use anyhow::Result;
+use anyhow::{Context, Result};
+use clap::Subcommand;
 use fuel_crypto::{Message, SecretKey, Signature};
 use fuel_types::Bytes32;
 use rpassword::prompt_password;
-use std::{path::Path, str::FromStr};
+use std::{
+    path::{Path, PathBuf},
+    str::FromStr,
+};
 
-fn sign_transaction(
-    tx_id: Bytes32,
-    account_index: usize,
-    password: &str,
-    path: &Path,
-) -> Result<Signature> {
-    let secret_key = account::derive_secret_key(path, account_index, password)?;
-    sign_transaction_with_private_key(tx_id, secret_key)
+#[derive(Debug, Subcommand)]
+pub(crate) enum Command {
+    /// Sign a transaction ID.
+    ///
+    /// The tx ID is signed directly, i.e. it is not re-hashed before signing.
+    ///
+    /// Previously `tx`, though renamed in anticipation of support for signing transaction files.
+    TxId { tx_id: fuel_types::Bytes32 },
+    /// Read the file at the given path into bytes and sign the raw data.
+    File { path: PathBuf },
+    /// Sign the given string as a slice of bytes.
+    String { string: String },
+    /// Parse the given hex-encoded byte string and sign the raw bytes.
+    ///
+    /// All characters must be within the range '0'..='f'. Each character pair
+    /// represents a single hex-encoded byte.
+    ///
+    /// The string may optionally start with the `0x` prefix which will be
+    /// discarded before decoding and signing the remainder of the string.
+    Hex { hex_string: String },
 }
 
-fn sign_transaction_with_private_key(tx_id: Bytes32, secret_key: SecretKey) -> Result<Signature> {
-    let message_hash = unsafe { Message::from_bytes_unchecked(*tx_id) };
-    let sig = Signature::sign(&secret_key, &message_hash);
-    Ok(sig)
+pub(crate) fn cli(wallet_path: &Path, account_ix: usize, cmd: Command) -> Result<()> {
+    match cmd {
+        Command::TxId { tx_id } => {
+            sign_msg_with_wallet_account_cli(wallet_path, account_ix, &msg_from_hash32(tx_id))?
+        }
+        Command::File { path } => {
+            sign_msg_with_wallet_account_cli(wallet_path, account_ix, &msg_from_file(&path)?)?
+        }
+        Command::Hex { hex_string } => sign_msg_with_wallet_account_cli(
+            wallet_path,
+            account_ix,
+            &msg_from_hex_str(&hex_string)?,
+        )?,
+        Command::String { string } => {
+            sign_msg_with_wallet_account_cli(wallet_path, account_ix, &Message::new(string))?
+        }
+    }
+    Ok(())
 }
 
-pub(crate) fn sign_transaction_with_private_key_cli(tx_id: Bytes32) -> Result<()> {
+pub(crate) fn private_key_cli(cmd: Command) -> Result<()> {
+    match cmd {
+        Command::TxId { tx_id } => sign_msg_with_private_key_cli(&msg_from_hash32(tx_id))?,
+        Command::File { path } => sign_msg_with_private_key_cli(&msg_from_file(&path)?)?,
+        Command::Hex { hex_string } => {
+            sign_msg_with_private_key_cli(&msg_from_hex_str(&hex_string)?)?
+        }
+        Command::String { string } => sign_msg_with_private_key_cli(&Message::new(string))?,
+    }
+    Ok(())
+}
+
+fn sign_msg_with_private_key_cli(msg: &Message) -> Result<()> {
     let secret_key_input = prompt_password("Please enter the private key you wish to sign with: ")?;
     let secret_key = SecretKey::from_str(&secret_key_input)?;
-    let signature = sign_transaction_with_private_key(tx_id, secret_key)?;
+    let signature = Signature::sign(&secret_key, msg);
     println!("Signature: {signature}");
     Ok(())
 }
 
-pub(crate) fn sign_transaction_cli(
+fn sign_msg_with_wallet_account_cli(
     wallet_path: &Path,
-    tx_id: Bytes32,
-    account_index: usize,
+    account_ix: usize,
+    msg: &Message,
 ) -> Result<()> {
     let password = prompt_password("Please enter your password: ")?;
-    let signature = sign_transaction(tx_id, account_index, &password, wallet_path)?;
+    let signature = sign_msg_with_wallet_account(wallet_path, account_ix, msg, &password)?;
     println!("Signature: {signature}");
     Ok(())
+}
+
+fn sign_msg_with_wallet_account(
+    wallet_path: &Path,
+    account_ix: usize,
+    msg: &Message,
+    pw: &str,
+) -> Result<Signature> {
+    let secret_key = account::derive_secret_key(wallet_path, account_ix, pw)?;
+    Ok(Signature::sign(&secret_key, msg))
+}
+
+// Cast the `Bytes32` directly to a message without normalizing it.
+// We don't renormalize as a hash is already a normalized representation.
+fn msg_from_hash32(hash: Bytes32) -> Message {
+    unsafe { Message::from_bytes_unchecked(hash.into()) }
+}
+
+fn msg_from_file(path: &Path) -> Result<Message> {
+    let bytes = std::fs::read(path).context("failed to read bytes from path")?;
+    Ok(Message::new(bytes))
+}
+
+fn msg_from_hex_str(hex_str: &str) -> Result<Message> {
+    let bytes = bytes_from_hex_str(hex_str)?;
+    Ok(Message::new(bytes))
+}
+
+fn bytes_from_hex_str(mut hex_str: &str) -> Result<Vec<u8>> {
+    // Strip the optional prefix.
+    const OPTIONAL_PREFIX: &str = "0x";
+    if hex_str.starts_with(OPTIONAL_PREFIX) {
+        hex_str = &hex_str[OPTIONAL_PREFIX.len()..];
+    }
+    hex::decode(hex_str).context("failed to decode bytes from hex string")
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::utils::test_utils::{save_dummy_wallet_file, with_tmp_folder, TEST_PASSWORD};
+    use crate::utils::test_utils::{with_tmp_dir_and_wallet, TEST_PASSWORD};
+    use fuel_crypto::Message;
+
     #[test]
-    fn sign_dummy_transaction() {
-        with_tmp_folder(|tmp_folder| {
-            let wallet_path = tmp_folder.join("wallet.json");
-            // initialize a wallet
-            save_dummy_wallet_file(&wallet_path);
+    fn sign_tx_id() {
+        with_tmp_dir_and_wallet(|_dir, wallet_path| {
             let tx_id = Bytes32::from_str(
                 "0x6c226b276bd2028c0582229b6396f91801c913973487491b0262c5c7b3cd6e39",
             )
             .unwrap();
-            let sig = sign_transaction(tx_id, 0, TEST_PASSWORD, &wallet_path).unwrap();
+            let msg = msg_from_hash32(tx_id);
+            let account_ix = 0;
+            let sig =
+                sign_msg_with_wallet_account(wallet_path, account_ix, &msg, TEST_PASSWORD).unwrap();
             assert_eq!(sig.to_string(), "bcf4651f072130aaf8925610e1d719b76e25b19b0a86779d3f4294964f1607cc95eb6c58eb37bf0510f618bd284decdf936c48ec6722df5472084e4098d54620");
+        });
+    }
+
+    const TEST_STR: &str = "Blah blah blah";
+    const EXPECTED_SIG: &str = "b0b2f29b52d95c1cba47ea7c7edeec6c84a0bd196df489e219f6f388b69d760479b994f4bae2d5f2abef7d5faf7d9f5ee3ea47ada4d15b7a7ee2777dcd7b36bb";
+
+    #[test]
+    fn sign_string() {
+        with_tmp_dir_and_wallet(|_dir, wallet_path| {
+            let msg = Message::new(TEST_STR);
+            let account_ix = 0;
+            let sig =
+                sign_msg_with_wallet_account(wallet_path, account_ix, &msg, TEST_PASSWORD).unwrap();
+            assert_eq!(sig.to_string(), EXPECTED_SIG);
+        });
+    }
+
+    #[test]
+    fn sign_file() {
+        with_tmp_dir_and_wallet(|dir, wallet_path| {
+            let path = dir.join("data");
+            std::fs::write(&path, TEST_STR).unwrap();
+            let msg = msg_from_file(&path).unwrap();
+            let account_ix = 0;
+            let sig =
+                sign_msg_with_wallet_account(wallet_path, account_ix, &msg, TEST_PASSWORD).unwrap();
+            assert_eq!(sig.to_string(), EXPECTED_SIG);
+        });
+    }
+
+    #[test]
+    fn sign_hex() {
+        with_tmp_dir_and_wallet(|_dir, wallet_path| {
+            let hex_encoded = hex::encode(TEST_STR);
+            let msg = msg_from_hex_str(&hex_encoded).unwrap();
+            let account_ix = 0;
+            let sig =
+                sign_msg_with_wallet_account(wallet_path, account_ix, &msg, TEST_PASSWORD).unwrap();
+            assert_eq!(sig.to_string(), EXPECTED_SIG);
         });
     }
 }

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -106,13 +106,7 @@ pub(crate) fn wallet_account_cli(wallet_path: &Path, account_ix: usize, data: Da
 }
 
 pub(crate) fn private_key_cli(data: Data) -> Result<()> {
-    match data {
-        Data::TxId { tx_id } => sign_msg_with_private_key_cli(&msg_from_hash32(tx_id))?,
-        Data::File { path } => sign_msg_with_private_key_cli(&msg_from_file(&path)?)?,
-        Data::Hex { hex_string } => sign_msg_with_private_key_cli(&msg_from_hex_str(&hex_string)?)?,
-        Data::String { string } => sign_msg_with_private_key_cli(&Message::new(string))?,
-    }
-    Ok(())
+    sign_msg_with_private_key_cli(&msg_from_data(data)?)
 }
 
 fn sign_msg_with_private_key_cli(msg: &Message) -> Result<()> {

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -148,8 +148,8 @@ fn sign_msg_with_wallet_account(
     Ok(Signature::sign(&secret_key, msg))
 }
 
-// Cast the `Bytes32` directly to a message without normalizing it.
-// We don't renormalize as a hash is already a normalized representation.
+/// Cast the `Bytes32` directly to a message without normalizing it.
+/// We don't renormalize as a hash is already a normalized representation.
 fn msg_from_hash32(hash: Bytes32) -> Message {
     unsafe { Message::from_bytes_unchecked(hash.into()) }
 }

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -20,19 +20,19 @@ pub struct Sign {
     /// Sign using a private key.
     /// Uses a discrete interactive prompt for collecting the private key.
     #[clap(long)]
-    pub private: bool,
+    pub private_key: bool,
     /// Sign by passing the private key directly.
     ///
     /// WARNING: This is primarily provided for non-interactive testing. Using this flag is
     /// prone to leaving your private key exposed in your shell command history!
     #[clap(long)]
-    pub private_key: Option<SecretKey>,
+    pub private_key_non_interactive: Option<SecretKey>,
     /// Directly provide the wallet password when signing with an account.
     ///
     /// WARNING: This is primarily provided for non-interactive testing. Using this flag is
     /// prone to leaving your password exposed in your shell command history!
     #[clap(long)]
-    pub password: Option<String>,
+    pub password_non_interactive: Option<String>,
     #[clap(subcommand)]
     pub data: Data,
 }
@@ -63,12 +63,17 @@ pub enum Data {
 pub(crate) fn cli(wallet_path: &Path, sign: Sign) -> Result<()> {
     let Sign {
         account,
-        private,
         private_key,
-        password,
+        private_key_non_interactive,
+        password_non_interactive,
         data,
     } = sign;
-    match (account, password, private, private_key) {
+    match (
+        account,
+        password_non_interactive,
+        private_key,
+        private_key_non_interactive,
+    ) {
         // Provided an account index, so we'll request the password.
         (Some(acc_ix), None, false, None) => wallet_account_cli(wallet_path, acc_ix, data)?,
         // Provided the password as a flag, so no need for interactive step.


### PR DESCRIPTION
This PR allows the user to sign arbitrary data. Here are some examples taken from the help output:

```console
    # Sign an arbitrary string.
    forc wallet account 3 sign string "blah blah blah"

    # Sign the contents of a file.
    forc wallet account 3 sign file /path/to/data-to-sign

    # Sign a hex-encoded byte string.
    forc wallet account 3 sign hex "0xDEADBEEF"
```

This PR also re-introduces the `forc wallet sign` subcommand. This re-uses the existing logic for signing via the account subcommand, though provides the additional option of signing with a private key. Some examples:

```console
    # You can also use the `sign` subcommand directly. The following gives the same result.
    forc wallet sign --account 3 string "blah blah blah"

    # Sign directly with a private key provided via interactive prompt.
    forc wallet sign --private-key string "blah blah blah"
```

Notably, this PR also removes the old `forc wallet sign-private` command in favour of using `forc wallet sign --private-key` in order to try and provide a more uniform interface.

The `sign tx` subcommand has been renamed to `sign tx-id` in anticipation of supporting signing transaction *files* in the future. See #89.

The `sign` command also now allows for specifying the full private key or account password via command line arguments (`--private-key-non-interactive <key>` and `--password-non-interactive <pw>` respectively), however these should likely only be used for testing in non-interactive environments. As a result, we don't highlight them as options in the help output, and we provide `WARNING`s about their use in their argument help output.

Closes #75.