### PR TITLE
feat: add support for displaying public key for an account derived with `forc-wallet`

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,3 +133,11 @@ To retrieve the private key of a specific account, you can use:
 ```sh
 forc-wallet account <account_index> private-key
 ```
+
+### Get public key of an account
+
+To retrieve the public key of a specific account, you can use:
+
+```sh
+forc-wallet account <account_index> public-key
+```

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,6 +95,9 @@ EXAMPLES:
 
     # Temporarily display the private key of the account at index 0.
     forc wallet account 0 private-key
+
+    # Show the public key of the account at index 0.
+    forc wallet account 0 public key
 "#;
 
 #[tokio::main]

--- a/src/main.rs
+++ b/src/main.rs
@@ -97,7 +97,7 @@ EXAMPLES:
     forc wallet account 0 private-key
 
     # Show the public key of the account at index 0.
-    forc wallet account 0 public key
+    forc wallet account 0 public-key
 "#;
 
 #[tokio::main]


### PR DESCRIPTION
closes #91.

This PR is adding `public-key` subcommand to `account` command. 

Example usage is:  `forc-wallet account <account_index> public-key` 