### PR TITLE
Add `balance` and `account <ix> balance` subcommands for printing all asset balances

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -909,15 +909,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
-name = "fastrand"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
-dependencies = [
- "instant",
-]
-
-[[package]]
 name = "ff"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -942,7 +933,6 @@ dependencies = [
  "eth-keystore 0.5.0",
  "fuel-crypto",
  "fuel-types",
- "fuels",
  "fuels-signers",
  "hex",
  "home",
@@ -1146,22 +1136,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fuels"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cb5af8cab660ba02d2e61bc16812fdd6e93f64a5c023d510d7fb615e400704c"
-dependencies = [
- "fuel-core-client",
- "fuel-tx",
- "fuels-core",
- "fuels-macros",
- "fuels-programs",
- "fuels-signers",
- "fuels-test-helpers",
- "fuels-types",
-]
-
-[[package]]
 name = "fuels-code-gen"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1213,35 +1187,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fuels-programs"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bacdabf09515dc95f3251d80ade1a876da951d988d48866c80940d594280a796"
-dependencies = [
- "bytes",
- "fuel-abi-types",
- "fuel-tx",
- "fuel-types",
- "fuel-vm",
- "fuels-core",
- "fuels-signers",
- "fuels-types",
- "futures",
- "hex",
- "itertools",
- "proc-macro2",
- "rand",
- "regex",
- "serde",
- "serde_json",
- "sha2 0.9.9",
- "strum",
- "strum_macros",
- "thiserror",
- "tokio",
-]
-
-[[package]]
 name = "fuels-signers"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1267,34 +1212,6 @@ dependencies = [
  "tai64",
  "thiserror",
  "tokio",
-]
-
-[[package]]
-name = "fuels-test-helpers"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "944433f739289f94e5a415684251211cfdb511849b58e2350c524a9b0d60f1c5"
-dependencies = [
- "fuel-core-chain-config",
- "fuel-core-client",
- "fuel-core-types",
- "fuel-tx",
- "fuel-types",
- "fuel-vm",
- "fuels-core",
- "fuels-programs",
- "fuels-signers",
- "fuels-types",
- "futures",
- "hex",
- "portpicker",
- "rand",
- "serde",
- "serde_json",
- "serde_with",
- "tempfile",
- "tokio",
- "which",
 ]
 
 [[package]]
@@ -1754,15 +1671,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2061,15 +1969,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "portpicker"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be97d76faf1bfab666e1375477b23fde79eccf0276e9b63b92a39d676a889ba9"
-dependencies = [
- "rand",
-]
-
-[[package]]
 name = "postcard"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2198,15 +2097,6 @@ name = "regex-syntax"
 version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
-
-[[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "reqwest"
@@ -2576,7 +2466,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "678b5a069e50bf00ecd22d0cd8ddf7c236f68581b03db652061ed5eb13a312ff"
 dependencies = [
  "serde",
- "serde_json",
  "serde_with_macros",
 ]
 
@@ -2791,20 +2680,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed7401421025f4132e6c1f7af5e7f8287383969f36e6628016cd509b8d3da9dc"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "tempfile"
-version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
-dependencies = [
- "cfg-if",
- "fastrand",
- "libc",
- "redox_syscall",
- "remove_dir_all",
- "winapi",
 ]
 
 [[package]]
@@ -3247,17 +3122,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
 dependencies = [
  "webpki 0.22.0",
-]
-
-[[package]]
-name = "which"
-version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269"
-dependencies = [
- "either",
- "libc",
- "once_cell",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -942,6 +942,7 @@ dependencies = [
  "termion",
  "tiny-bip39",
  "tokio",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -934,6 +934,8 @@ dependencies = [
  "fuel-crypto",
  "fuel-types",
  "fuels-signers",
+ "fuels-types",
+ "futures",
  "hex",
  "home",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,4 @@ serde_json = "1.0"
 termion = "2.0"
 tiny-bip39 = "1.0"
 tokio = { version = "1.10.1", features = ["full"] }
+url = "2.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ clap = { version = "3.1", features = ["derive"] }
 eth-keystore = { version = "0.5" }
 fuel-crypto = "0.26"
 fuel-types = "0.26"
-fuels = { version = "0.36.0", default-features = false }
 fuels-signers = "0.36.0"
 hex = "0.4"
 home = "0.5.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,8 @@ eth-keystore = { version = "0.5" }
 fuel-crypto = "0.26"
 fuel-types = "0.26"
 fuels-signers = "0.36.0"
+fuels-types = "0.36.0"
+futures = "0.3"
 hex = "0.4"
 home = "0.5.3"
 rand = { version = "0.8.4", default-features = false }

--- a/src/account.rs
+++ b/src/account.rs
@@ -70,7 +70,7 @@ struct Unverified {
 
 #[derive(Debug, Args)]
 pub(crate) struct Balance {
-    #[clap(long, default_value_t = crate::BETA_2_URL.parse().unwrap())]
+    #[clap(long, default_value_t = crate::DEFAULT_URL.parse().unwrap())]
     node_url: Url,
     #[clap(flatten)]
     unverified: Unverified,

--- a/src/account.rs
+++ b/src/account.rs
@@ -6,7 +6,7 @@ use anyhow::{anyhow, bail, Context, Result};
 use clap::{Args, Subcommand};
 use eth_keystore::EthKeystore;
 use fuel_crypto::{PublicKey, SecretKey};
-use fuels::prelude::WalletUnlocked;
+use fuels_signers::WalletUnlocked;
 use std::{
     collections::BTreeMap,
     fs,

--- a/src/account.rs
+++ b/src/account.rs
@@ -76,7 +76,7 @@ pub(crate) struct Balance {
     unverified: Unverified,
 }
 
-// A map from an account's index to its bech32 address.
+/// A map from an account's index to its bech32 address.
 type AccountAddresses = BTreeMap<usize, Bech32Address>;
 
 pub(crate) async fn cli(wallet_path: &Path, account: Account) -> Result<()> {

--- a/src/import.rs
+++ b/src/import.rs
@@ -1,6 +1,6 @@
 use crate::utils::{request_new_password, write_wallet_from_mnemonic_and_password};
 use anyhow::{bail, Result};
-use fuels::signers::wallet::WalletUnlocked;
+use fuels_signers::WalletUnlocked;
 use std::path::Path;
 
 /// Check if given mnemonic is valid by trying to create a `WalletUnlocked` from it

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use crate::{
     sign::Sign,
 };
 use anyhow::Result;
-use clap::{Parser, Subcommand};
+use clap::{Args, Parser, Subcommand};
 use std::path::PathBuf;
 
 #[derive(Debug, Parser)]
@@ -58,7 +58,18 @@ enum Command {
     ///
     /// Only includes accounts that have been previously derived, i.e. those
     /// that show under `forc-wallet accounts`.
-    Balance(account::Balance),
+    Balance(Balance),
+}
+
+#[derive(Debug, Args)]
+struct Balance {
+    // Account-specific args.
+    #[clap(flatten)]
+    account: account::Balance,
+    /// Show the balance for each individual non-empty account before showing
+    /// the total.
+    #[clap(long)]
+    accounts: bool,
 }
 
 /// The default network used in the case that none is specified.

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,6 +73,7 @@ struct Balance {
 }
 
 /// The default network used in the case that none is specified.
+const DEFAULT_URL: &str = BETA_2_URL;
 const BETA_2_URL: &str = "https://node-beta-2.fuel.network";
 const BETA_2_FAUCET_URL: &str = "https://faucet-beta-2.fuel.network";
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,6 @@ use crate::{
 };
 use anyhow::Result;
 use clap::{Parser, Subcommand};
-use fuels::prelude::*;
 use std::path::PathBuf;
 
 #[derive(Debug, Parser)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,6 +56,10 @@ enum Command {
     Sign(Sign),
 }
 
+/// The default network used in the case that none is specified.
+const BETA_2_URL: &str = "https://node-beta-2.fuel.network";
+const BETA_2_FAUCET_URL: &str = "https://faucet-beta-2.fuel.network";
+
 const ABOUT: &str = "A forc plugin for generating or importing wallets using BIP39 phrases.";
 const EXAMPLES: &str = r#"
 EXAMPLES:
@@ -107,7 +111,7 @@ async fn main() -> Result<()> {
         Command::New => new_wallet_cli(&wallet_path)?,
         Command::Import => import_wallet_cli(&wallet_path)?,
         Command::Accounts(accounts) => account::print_accounts_cli(&wallet_path, accounts)?,
-        Command::Account(account) => account::cli(&wallet_path, account)?,
+        Command::Account(account) => account::cli(&wallet_path, account).await?,
         Command::Sign(sign) => sign::cli(&wallet_path, sign)?,
     }
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,6 +54,11 @@ enum Command {
     /// account's public or private key. See the `EXAMPLES` below.
     Account(Account),
     Sign(Sign),
+    /// Present the sum of all account balances under a single wallet balance.
+    ///
+    /// Only includes accounts that have been previously derived, i.e. those
+    /// that show under `forc-wallet accounts`.
+    Balance(account::Balance),
 }
 
 /// The default network used in the case that none is specified.
@@ -113,6 +118,7 @@ async fn main() -> Result<()> {
         Command::Accounts(accounts) => account::print_accounts_cli(&wallet_path, accounts)?,
         Command::Account(account) => account::cli(&wallet_path, account).await?,
         Command::Sign(sign) => sign::cli(&wallet_path, sign)?,
+        Command::Balance(balance) => account::balance_cli(&wallet_path, &balance).await?,
     }
     Ok(())
 }

--- a/src/new.rs
+++ b/src/new.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 pub(crate) fn new_wallet_cli(wallet_path: &Path) -> anyhow::Result<()> {
     let password = request_new_password();
     // Generate a random mnemonic phrase.
-    let mnemonic = fuels::signers::wallet::generate_mnemonic_phrase(&mut rand::thread_rng(), 24)?;
+    let mnemonic = fuels_signers::wallet::generate_mnemonic_phrase(&mut rand::thread_rng(), 24)?;
     write_wallet_from_mnemonic_and_password(wallet_path, &mnemonic, &password)?;
     let mnemonic_string = format!("Wallet mnemonic phrase: {mnemonic}\n");
     display_string_discreetly(

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,3 @@
-use crate::Error;
 use anyhow::{anyhow, bail, Context, Result};
 use eth_keystore::EthKeystore;
 use fuels_signers::wallet::DEFAULT_DERIVATION_PATH_PREFIX;
@@ -80,7 +79,7 @@ pub(crate) fn request_new_password() -> String {
 pub(crate) fn display_string_discreetly(
     discreet_string: &str,
     continue_message: &str,
-) -> Result<(), Error> {
+) -> Result<()> {
     use termion::screen::IntoAlternateScreen;
     let mut screen = std::io::stdout().into_alternate_screen()?;
     writeln!(screen, "{discreet_string}")?;


### PR DESCRIPTION
Show the balance of the specified account:
```console
forc wallet account <ix> balance
```

Show the total balance for the whole wallet:
```console
forc wallet balance
```

Show the balance of each non-empty account prior to the wallet total:
```console
forc wallet balance --accounts
```

Demo:

```console
$ forc wallet account 0 balance
Please enter your password to verify account 0:
Verifying account 0
Connecting to https://node-beta-2.fuel.network/
Fetching the balance of the following account:
    0: fuel1htrldg7wpelrnhvad8lwcep57duhpxmj2h6a55nhr4md4839cy2q04p3tu

Account 0:
  Asset ID                                                           Amount
  0x0000000000000000000000000000000000000000000000000000000000000000 1000000000

$ forc wallet account 1 balance
Please enter your password to verify account 1:
Verifying account 1
Connecting to https://node-beta-2.fuel.network/
Fetching the balance of the following account:
    1: fuel1vjnvqkvea7hhluhh8alwt7yuq0nj7d0sfa2vxu3q5drna5ujrzmqy0k43h

Account 1:
  Asset ID                                                           Amount
  0x0000000000000000000000000000000000000000000000000000000000000000 500000000

$ forc wallet account 2 balance
Please enter your password to verify account 2:
Verifying account 2
Connecting to https://node-beta-2.fuel.network/
Fetching the balance of the following account:
    2: fuel13c78d66334nqnrat322gfszne77a8tklhfklkshk0fmdq2e0dscsdyrs8u

Account 2:
  Account empty. Visit the faucet to acquire some test funds: https://faucet-beta-2.fuel.network

$ forc wallet balance
Please enter your password to verify accounts:
Verifying account 0
Verifying account 1
Verifying account 2
Verifying account 9
Connecting to https://node-beta-2.fuel.network/
Fetching and summing balances of the following accounts:
    0: fuel1htrldg7wpelrnhvad8lwcep57duhpxmj2h6a55nhr4md4839cy2q04p3tu
    1: fuel1vjnvqkvea7hhluhh8alwt7yuq0nj7d0sfa2vxu3q5drna5ujrzmqy0k43h
    2: fuel13c78d66334nqnrat322gfszne77a8tklhfklkshk0fmdq2e0dscsdyrs8u
    9: fuel14f6e7arrxqz8vjc0dyp8yhzng9r2u4wjvm89falk9d2y9vv6l6mq5rj3mf

Total:
  Asset ID                                                           Amount
  0x0000000000000000000000000000000000000000000000000000000000000000 1500000000

$ forc wallet balance --accounts
Please enter your password to verify accounts:
Verifying account 0
Verifying account 1
Verifying account 2
Verifying account 9
Connecting to https://node-beta-2.fuel.network/
Fetching and summing balances of the following accounts:
    0: fuel1htrldg7wpelrnhvad8lwcep57duhpxmj2h6a55nhr4md4839cy2q04p3tu
    1: fuel1vjnvqkvea7hhluhh8alwt7yuq0nj7d0sfa2vxu3q5drna5ujrzmqy0k43h
    2: fuel13c78d66334nqnrat322gfszne77a8tklhfklkshk0fmdq2e0dscsdyrs8u
    9: fuel14f6e7arrxqz8vjc0dyp8yhzng9r2u4wjvm89falk9d2y9vv6l6mq5rj3mf

Account 0:
  Asset ID                                                           Amount
  0x0000000000000000000000000000000000000000000000000000000000000000 1000000000

Account 1:
  Asset ID                                                           Amount
  0x0000000000000000000000000000000000000000000000000000000000000000 500000000

Total:
  Asset ID                                                           Amount
  0x0000000000000000000000000000000000000000000000000000000000000000 1500000000
```

Just like for the `account` and `accounts` subcommands, the `--unverified` flag allows for retrieving the address associated with an account index without verification to avoid the need to re-enter the password (useful for testing).

The `--node-url` flag allows for specifying the network URL. This PR defaults the value to the beta-2 network. Thinking further, we may prefer to default to a local network for safety, and require that remote networks are specified manually. I'll update the PR to make this change.

This should make it easier to test and implement #65.

## TODO

- [x] Add a more general wallet balance summary command that aggregates the balance of each known account.

### Follow-up

- Add option for listing all individual UTXOs (not just full balance). #97.

Closes #68 