### PR TITLE
Add derivation for plain address into forc-wallet

### DIFF
--- a/src/account.rs
+++ b/src/account.rs
@@ -17,9 +17,9 @@ use url::Url;
 
 #[derive(Debug, Args)]
 pub(crate) struct Accounts {
-    /// Contains optional flag for displaying all accounts as hex / bytes values. 
-    /// 
-    /// pass in --as-hex for this alternative display. 
+    /// Contains optional flag for displaying all accounts as hex / bytes values.
+    ///
+    /// pass in --as-hex for this alternative display.
     #[clap(flatten)]
     unverified: Unverified,
     #[clap(long)]
@@ -39,7 +39,7 @@ pub(crate) struct Account {
 }
 
 #[derive(Debug, Args)]
-pub(crate) struct Fmt{
+pub(crate) struct Fmt {
     /// Option for public key to be displayed as hex / bytes.
     ///  
     /// pass in --as-hex for this alternative display.
@@ -67,7 +67,7 @@ pub(crate) enum Command {
     /// temporary, terminal window!
     PrivateKey,
     /// Reveal the public key for the specified account.
-    /// Takes an optional bool flag --as-hex that displays the PublicKey in hex format. 
+    /// Takes an optional bool flag --as-hex that displays the PublicKey in hex format.
     PublicKey(Fmt),
     /// Print each asset balance associated with the specified account.
     Balance(Balance),
@@ -104,12 +104,10 @@ pub(crate) async fn cli(wallet_path: &Path, account: Account) -> Result<()> {
             sign::wallet_account_cli(wallet_path, acc_ix, sign_cmd)?
         }
         (Some(acc_ix), Some(Command::PrivateKey)) => private_key_cli(wallet_path, acc_ix)?,
-        (Some(acc_ix), Some(Command::PublicKey(format))) =>{
-            match format.as_hex {
-                true => hex_address_cli(wallet_path, acc_ix)?,
-                false => public_key_cli(wallet_path, acc_ix)?,
-            }
-        } ,
+        (Some(acc_ix), Some(Command::PublicKey(format))) => match format.as_hex {
+            true => hex_address_cli(wallet_path, acc_ix)?,
+            false => public_key_cli(wallet_path, acc_ix)?,
+        },
         (Some(acc_ix), Some(Command::Balance(balance))) => {
             account_balance_cli(wallet_path, acc_ix, &balance).await?
         }
@@ -270,13 +268,11 @@ pub(crate) fn print_accounts_cli(wallet_path: &Path, accounts: Accounts) -> Resu
         println!("Account addresses (unverified, printed from cache):");
         addresses
             .iter()
-            .for_each(|(ix, addr)| {
-                match accounts.as_hex{
-                    false => println!("[{ix}] {addr}"),
-                    true => {
-                        let bytes_addr: fuel_types::Address = addr.into();
-                        println!("[{ix}] {bytes_addr}");
-                    }
+            .for_each(|(ix, addr)| match accounts.as_hex {
+                false => println!("[{ix}] {addr}"),
+                true => {
+                    let bytes_addr: fuel_types::Address = addr.into();
+                    println!("[{ix}] {bytes_addr}");
                 }
             });
     } else {
@@ -285,14 +281,14 @@ pub(crate) fn print_accounts_cli(wallet_path: &Path, accounts: Accounts) -> Resu
         for &ix in addresses.keys() {
             let account = derive_account(wallet_path, ix, &password)?;
             let account_addr = account.address();
-            match accounts.as_hex{
+            match accounts.as_hex {
                 false => println!("[{ix}] {account_addr}"),
                 true => {
                     let bytes_addr: fuel_types::Address = account_addr.into();
                     println!("[{ix}] {bytes_addr}");
                 }
             }
-            
+
             cache_address(&wallet.crypto.ciphertext, ix, account_addr)?;
         }
     }

--- a/src/account.rs
+++ b/src/account.rs
@@ -406,7 +406,7 @@ fn public_key_cli(wallet_path: &Path, account_ix: usize) -> Result<()> {
 //Prints the plain Address formatted pub key @{account_ix} (the one that doesn't start with 'fuel...')
 fn plain_address_cli(wallet_path: &Path, account_ix: usize) -> Result<()> {
     let prompt =
-        format!("Please enter your password to display account {account_ix}'s public key: ");
+        format!("Please enter your password to display account {account_ix}'s plain address: ");
     let password = rpassword::prompt_password(prompt)?;
     let secret_key = derive_secret_key(wallet_path, account_ix, &password)?;
     let public_key = format!("{}", PublicKey::from(&secret_key));

--- a/src/account.rs
+++ b/src/account.rs
@@ -403,7 +403,7 @@ fn public_key_cli(wallet_path: &Path, account_ix: usize) -> Result<()> {
     Ok(())
 }
 
-//Prints the plain Address formatted pub key @{account_ix} (the one that doesn't start with 'fuel...')
+/// Prints the plain address for the given account index
 fn plain_address_cli(wallet_path: &Path, account_ix: usize) -> Result<()> {
     let prompt =
         format!("Please enter your password to display account {account_ix}'s plain address: ");

--- a/src/account.rs
+++ b/src/account.rs
@@ -54,7 +54,7 @@ pub(crate) enum Command {
     PrivateKey,
     /// Reveal the public key for the specified account.
     PublicKey,
-    /// Reveal the plain address for the specified account. 
+    /// Reveal the plain address for the specified account.
     PlainAddress,
     /// Print each asset balance associated with the specified account.
     Balance(Balance),
@@ -410,7 +410,7 @@ fn plain_address_cli(wallet_path: &Path, account_ix: usize) -> Result<()> {
     let password = rpassword::prompt_password(prompt)?;
     let secret_key = derive_secret_key(wallet_path, account_ix, &password)?;
     let public_key = format!("{}", PublicKey::from(&secret_key));
-    let bech = Bech32Address::from_str(&public_key).expect("failed to create Bech32 address from String");
+    let bech = Bech32Address::from_str(&public_key)?;
     let plain_address: fuel_types::Address = bech.into();
     println!("Plain address for {}: {}", account_ix, plain_address);
     Ok(())
@@ -507,13 +507,16 @@ mod tests {
         });
     }
     #[test]
-    fn derive_plain_address(){
+    fn derive_plain_address() {
         let address = "fuel1j78es08cyyz5n75jugal7p759ccs323etnykzpndsvhzu6399yqqpjmmd2";
-        let bech32 =
-            <fuels_types::bech32::Bech32Address as std::str::FromStr>::from_str(address).expect("failed to create Bech32 address from string");
+        let bech32 = <fuels_types::bech32::Bech32Address as std::str::FromStr>::from_str(address)
+            .expect("failed to create Bech32 address from string");
         let plain_address: fuel_types::Address = bech32.into();
         assert_eq!(
-            <fuel_types::Address as std::str::FromStr>::from_str("978f983cf8210549fa92e23bff07d42e3108aa395cc961066d832e2e6a252900").expect("RIP"),
+            <fuel_types::Address as std::str::FromStr>::from_str(
+                "978f983cf8210549fa92e23bff07d42e3108aa395cc961066d832e2e6a252900"
+            )
+            .expect("RIP"),
             plain_address
         )
     }

--- a/src/account.rs
+++ b/src/account.rs
@@ -54,7 +54,7 @@ pub(crate) enum Command {
     PrivateKey,
     /// Reveal the public key for the specified account.
     PublicKey,
-    // Reveal the plain address for the specified account. 
+    /// Reveal the plain address for the specified account. 
     PlainAddress,
     /// Print each asset balance associated with the specified account.
     Balance(Balance),


### PR DESCRIPTION
By default, we are given the Bech32 format of the public key from the forc-wallet account command, whereas, for Sway, it is required that we use a plain address in the contract. For the convenience of developers, I rigged up the functionality to derive the plain address directly from the CLI with a unit test that sanity checks the type conversion.