### PR TITLE
Add beta-3 network URL. Switch to beta-3 as the default.

### DIFF
--- a/src/account.rs
+++ b/src/account.rs
@@ -70,7 +70,7 @@ struct Unverified {
 
 #[derive(Debug, Args)]
 pub(crate) struct Balance {
-    #[clap(long, default_value_t = crate::DEFAULT_URL.parse().unwrap())]
+    #[clap(long, default_value_t = crate::network::DEFAULT.parse().unwrap())]
     node_url: Url,
     #[clap(flatten)]
     unverified: Unverified,
@@ -220,16 +220,17 @@ fn verify_address_and_update_cache(
 }
 
 fn print_balance_empty(node_url: &Url) {
-    let beta_2_url = crate::BETA_2_URL.parse::<Url>().unwrap();
-    match node_url.host_str() {
-        host if host == beta_2_url.host_str() => {
-            println!(
-                "  Account empty. Visit the faucet to acquire some test funds: {}",
-                crate::BETA_2_FAUCET_URL
-            )
-        }
-        _ => println!("Account empty,"),
-    }
+    let beta_2_url = crate::network::BETA_2.parse::<Url>().unwrap();
+    let beta_3_url = crate::network::BETA_3.parse::<Url>().unwrap();
+    let faucet_url = match node_url.host_str() {
+        host if host == beta_2_url.host_str() => crate::network::BETA_2_FAUCET,
+        host if host == beta_3_url.host_str() => crate::network::BETA_3_FAUCET,
+        _ => return println!("  Account empty."),
+    };
+    println!(
+        "  Account empty. Visit the faucet to acquire some test funds: {}",
+        faucet_url
+    );
 }
 
 fn print_balance(balance: &BTreeMap<String, u128>) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,9 +73,13 @@ struct Balance {
 }
 
 /// The default network used in the case that none is specified.
-const DEFAULT_URL: &str = BETA_2_URL;
-const BETA_2_URL: &str = "https://node-beta-2.fuel.network";
-const BETA_2_FAUCET_URL: &str = "https://faucet-beta-2.fuel.network";
+mod network {
+    pub(crate) const DEFAULT: &str = BETA_3;
+    pub(crate) const BETA_2: &str = "https://node-beta-2.fuel.network";
+    pub(crate) const BETA_2_FAUCET: &str = "https://faucet-beta-2.fuel.network";
+    pub(crate) const BETA_3: &str = "https://beta-3.fuel.network/";
+    pub(crate) const BETA_3_FAUCET: &str = "https://faucet-beta-3.fuel.network/";
+}
 
 const ABOUT: &str = "A forc plugin for generating or importing wallets using BIP39 phrases.";
 const EXAMPLES: &str = r#"


### PR DESCRIPTION
@bingcicle I'm thinking we probably want to release a new `forc-wallet` version and bump fuelup's beta-3 toolchain version too. I'll cut a patch release as a follow-up.