### PR TITLE
feat: transfer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -933,6 +933,7 @@ dependencies = [
  "eth-keystore 0.5.0",
  "fuel-crypto",
  "fuel-types",
+ "fuels-core",
  "fuels-signers",
  "fuels-types",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ clap = { version = "3.1", features = ["derive"] }
 eth-keystore = { version = "0.5" }
 fuel-crypto = "0.26"
 fuel-types = "0.26"
+fuels-core = "0.36.0"
 fuels-signers = "0.36.0"
 fuels-types = "0.36.0"
 futures = "0.3"

--- a/src/account.rs
+++ b/src/account.rs
@@ -100,10 +100,13 @@ pub(crate) struct Balance {
 #[derive(Debug, Args)]
 pub(crate) struct Transfer {
     // Bech32Address of the account to transfer assets to.
-    to: String,
+    #[clap(long)]
+    to: Bech32Address,
     // Amount (in u64) of assets to transfer.
+    #[clap(long)]
     amount: u64,
     // Asset ID of the asset to transfer.
+    #[clap(long)]
     asset_id: AssetId,
     #[clap(long, default_value_t = crate::network::DEFAULT.parse().unwrap())]
     node_url: Url,
@@ -493,12 +496,11 @@ pub(crate) async fn transfer_cli(
     let mut account = derive_account_unlocked(wallet_path, acc_ix, &password)?;
     let provider = fuels_signers::provider::Provider::connect(&transfer.node_url).await?;
     account.set_provider(provider);
-    let to_addr = transfer.to.parse::<Bech32Address>()?;
     println!("Transferring...");
 
     let (tx_id, receipts) = account
         .transfer(
-            &to_addr,
+            &transfer.to,
             1,
             Default::default(),
             TxParameters::new(

--- a/src/account.rs
+++ b/src/account.rs
@@ -135,7 +135,7 @@ impl FromStr for To {
             return Ok(Self::HexAddress(hex_address));
         }
 
-        return Err("Invalid addresss '{}': address must either be in bech32 or hex");
+        Err("Invalid address '{}': address must either be in bech32 or hex")
     }
 }
 

--- a/src/account.rs
+++ b/src/account.rs
@@ -464,7 +464,6 @@ fn public_key_cli(wallet_path: &Path, account_ix: usize) -> Result<()> {
     Ok(())
 }
 
-<<<<<<< HEAD
 /// Prints the plain address for the given account index
 fn hex_address_cli(wallet_path: &Path, account_ix: usize) -> Result<()> {
     let prompt =
@@ -510,10 +509,9 @@ pub(crate) async fn transfer_cli(
         )
         .await?;
 
-    let beta_3_url = crate::network::BETA_3.parse::<Url>().unwrap();
     let block_explorer_url = match transfer.node_url.host_str() {
-        host if host == beta_3_url.host_str() => {
-            "https://fuellabs.github.io/block-explorer-v2/beta-3"
+        host if host == crate::network::BETA_3.parse::<Url>().unwrap().host_str() => {
+            crate::explorer::DEFAULT
         }
         _ => "",
     };

--- a/src/account.rs
+++ b/src/account.rs
@@ -518,17 +518,11 @@ pub(crate) async fn transfer_cli(
         _ => "",
     };
 
+    let tx_explorer_url = format!("{block_explorer_url}/#/transaction/0x{tx_id}");
     println!(
-        "\nTransfer complete!\nSummary:\n  Transaction ID: 0x{tx_id}\n  Receipts: {:#?}",
+        "\nTransfer complete!\nSummary:\n  Transaction ID: 0x{tx_id}\n  Receipts: {:#?}\n  Explorer: {tx_explorer_url}\n",
         receipts
     );
-    if !block_explorer_url.is_empty() {
-        let tx_explorer_url = format!("{block_explorer_url}/#/transaction/0x{tx_id}");
-        println!(
-            "View this transaction on the block explorer: {}",
-            tx_explorer_url
-        );
-    };
 
     Ok(())
 }

--- a/src/account.rs
+++ b/src/account.rs
@@ -3,7 +3,7 @@ use crate::utils::{
     display_string_discreetly, get_derivation_path, load_wallet, user_fuel_wallets_accounts_dir,
 };
 use anyhow::{anyhow, bail, Context, Result};
-use clap::{Args, Parser, Subcommand};
+use clap::{Args, Subcommand};
 use eth_keystore::EthKeystore;
 use fuel_crypto::{PublicKey, SecretKey};
 use fuel_types::AssetId;
@@ -116,12 +116,6 @@ pub(crate) struct Transfer {
     gas_limit: u64,
     #[clap(long, default_value_t = DEFAULT_MATURITY)]
     maturity: u64,
-}
-
-#[derive(Debug, Parser)]
-pub struct TxParametersOpts {
-    #[clap(long)]
-    gas_price: Option<u64>,
 }
 
 /// A map from an account's index to its bech32 address.

--- a/src/account.rs
+++ b/src/account.rs
@@ -515,6 +515,9 @@ pub(crate) async fn transfer_cli(
         host if host == crate::network::BETA_3.parse::<Url>().unwrap().host_str() => {
             crate::explorer::DEFAULT
         }
+        host if host == crate::network::BETA_2.parse::<Url>().unwrap().host_str() => {
+            crate::explorer::BETA_2
+        }
         _ => "",
     };
 

--- a/src/account.rs
+++ b/src/account.rs
@@ -99,13 +99,13 @@ pub(crate) struct Balance {
 
 #[derive(Debug, Args)]
 pub(crate) struct Transfer {
-    // Bech32Address of the account to transfer assets to.
+    /// The bech32 address (in Bech32Address) of the account to transfer assets to.
     #[clap(long)]
     to: Bech32Address,
-    // Amount (in u64) of assets to transfer.
+    /// Amount (in u64) of assets to transfer.
     #[clap(long)]
     amount: u64,
-    // Asset ID of the asset to transfer.
+    /// Asset ID of the asset to transfer.
     #[clap(long)]
     asset_id: AssetId,
     #[clap(long, default_value_t = crate::network::DEFAULT.parse().unwrap())]

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,6 +84,7 @@ mod network {
 /// The default network used in the case that none is specified.
 mod explorer {
     pub(crate) const DEFAULT: &str = BETA_3;
+    pub(crate) const BETA_2: &str = "https://fuellabs.github.io/block-explorer-v2/beta-2";
     pub(crate) const BETA_3: &str = "https://fuellabs.github.io/block-explorer-v2/beta-3";
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,6 +81,12 @@ mod network {
     pub(crate) const BETA_3_FAUCET: &str = "https://faucet-beta-3.fuel.network/";
 }
 
+/// The default network used in the case that none is specified.
+mod explorer {
+    pub(crate) const DEFAULT: &str = BETA_3;
+    pub(crate) const BETA_3: &str = "https://fuellabs.github.io/block-explorer-v2/beta-3";
+}
+
 const ABOUT: &str = "A forc plugin for generating or importing wallets using BIP39 phrases.";
 const EXAMPLES: &str = r#"
 EXAMPLES:

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,7 +81,7 @@ mod network {
     pub(crate) const BETA_3_FAUCET: &str = "https://faucet-beta-3.fuel.network/";
 }
 
-/// The default network used in the case that none is specified.
+/// Contains definitions of URLs to the block explorer for each network.
 mod explorer {
     pub(crate) const DEFAULT: &str = BETA_3;
     pub(crate) const BETA_2: &str = "https://fuellabs.github.io/block-explorer-v2/beta-2";

--- a/src/main.rs
+++ b/src/main.rs
@@ -129,6 +129,14 @@ EXAMPLES:
 
     # Show the public key of the account at index 0.
     forc wallet account 0 public-key
+
+    # Transfer 1 token of the base asset id to a bech32 address at the gas price of 1. 
+    forc wallet account 0 transfer --to fuel1dq2vgftet24u4nkpzmtfus9k689ap5avkm8kdjna8j3d6765yfdsjt6586
+    --amount 1 --asset-id 0x0000000000000000000000000000000000000000000000000000000000000000 --gas-price 1
+
+    # Transfer 1 token of the base asset id to a hex address at the gas price of 1. 
+    forc wallet account 0 transfer --to 0x0b8d0f6a7f271919708530d11bdd9398205137e012424b611e9d97118c180bea 
+    --amount 1 --asset-id 0x0000000000000000000000000000000000000000000000000000000000000000 --gas-price 1
 "#;
 
 #[tokio::main]


### PR DESCRIPTION
Closes #65 

I took the liberty to name the command `transfer` instead of `send` to keep consistent with what's available in `fuels_signers`: https://docs.rs/fuels-signers/0.38.1/fuels_signers/wallet/struct.WalletUnlocked.html#method.transfer

Also added an additional feature that shows TX on the block explorer for convenience.

Preview:

![image](https://user-images.githubusercontent.com/25565268/228483462-569ebec3-a491-456a-9843-db1036c67b2c.png)
