### PR TITLE
feat: expose cli functionality as a lib

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,11 @@ termion = "2.0"
 tiny-bip39 = "1.0"
 tokio = { version = "1.10.1", features = ["full"] }
 url = "2.3"
+
+[lib]
+name = "forc_wallet"
+path = "src/lib.rs"
+
+[[bin]]
+name = "forc-wallet"
+path = "src/main.rs"

--- a/src/balance.rs
+++ b/src/balance.rs
@@ -1,0 +1,80 @@
+use anyhow::{anyhow, Result};
+use clap::Args;
+use std::{collections::BTreeMap, path::Path};
+
+use crate::{
+    account::{
+        derive_account, print_balance, print_balance_empty, read_cached_addresses,
+        verify_address_and_update_cache,
+    },
+    utils::load_wallet,
+};
+
+#[derive(Debug, Args)]
+pub struct Balance {
+    // Account-specific args.
+    #[clap(flatten)]
+    pub(crate) account: crate::account::Balance,
+    /// Show the balance for each individual non-empty account before showing
+    /// the total.
+    #[clap(long)]
+    accounts: bool,
+}
+
+pub async fn cli(wallet_path: &Path, balance: &Balance) -> Result<()> {
+    let wallet = load_wallet(wallet_path)?;
+    let mut addresses = read_cached_addresses(&wallet.crypto.ciphertext)?;
+    if !balance.account.unverified.unverified {
+        let prompt = "Please enter your password to verify accounts: ";
+        let password = rpassword::prompt_password(prompt)?;
+        for (&ix, addr) in addresses.iter_mut() {
+            let account = derive_account(wallet_path, ix, &password)?;
+            if verify_address_and_update_cache(ix, &account, addr, &wallet.crypto.ciphertext)? {
+                *addr = account.address().clone();
+            }
+        }
+    };
+    println!("Connecting to {}", balance.account.node_url);
+    let provider = fuels_signers::provider::Provider::connect(&balance.account.node_url).await?;
+    println!("Fetching and summing balances of the following accounts:");
+    for (ix, addr) in &addresses {
+        println!("  {ix:>3}: {addr}");
+    }
+    let accounts: Vec<_> = addresses
+        .values()
+        .map(|addr| fuels_signers::Wallet::from_address(addr.clone(), Some(provider.clone())))
+        .collect();
+    let account_balances =
+        futures::future::try_join_all(accounts.iter().map(|acc| acc.get_balances())).await?;
+
+    if balance.accounts {
+        for (ix, balance) in addresses.keys().zip(&account_balances) {
+            let balance: BTreeMap<_, _> = balance
+                .iter()
+                .map(|(id, &val)| (id.clone(), u128::from(val)))
+                .collect();
+            if balance.is_empty() {
+                continue;
+            }
+            println!("\nAccount {ix}:");
+            print_balance(&balance);
+        }
+    }
+
+    let mut total_balance = BTreeMap::default();
+    println!("\nTotal:");
+    for acc_bal in account_balances {
+        for (asset_id, amt) in acc_bal {
+            let entry = total_balance.entry(asset_id.clone()).or_insert(0u128);
+            *entry = entry.checked_add(u128::from(amt)).ok_or_else(|| {
+                anyhow!("Failed to display balance for asset {asset_id}: Value out of range.")
+            })?;
+        }
+    }
+    if total_balance.is_empty() {
+        print_balance_empty(&balance.account.node_url);
+    } else {
+        print_balance(&total_balance);
+    }
+    Ok(())
+}

--- a/src/import.rs
+++ b/src/import.rs
@@ -12,7 +12,7 @@ fn check_mnemonic(mnemonic: &str) -> Result<()> {
     Ok(())
 }
 
-pub(crate) fn import_wallet_cli(wallet_path: &Path) -> Result<()> {
+pub fn import_wallet_cli(wallet_path: &Path) -> Result<()> {
     let mnemonic = rpassword::prompt_password("Please enter your mnemonic phrase: ")?;
     check_mnemonic(&mnemonic)?;
     let password = request_new_password();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,21 @@
+pub mod account;
+pub mod import;
+pub mod new;
+pub mod sign;
+pub mod utils;
+
+/// The default network used in the case that none is specified.
+pub mod network {
+    pub const DEFAULT: &str = BETA_3;
+    pub const BETA_2: &str = "https://node-beta-2.fuel.network";
+    pub const BETA_2_FAUCET: &str = "https://faucet-beta-2.fuel.network";
+    pub const BETA_3: &str = "https://beta-3.fuel.network/";
+    pub const BETA_3_FAUCET: &str = "https://faucet-beta-3.fuel.network/";
+}
+
+/// Contains definitions of URLs to the block explorer for each network.
+pub mod explorer {
+    pub const DEFAULT: &str = BETA_3;
+    pub const BETA_2: &str = "https://fuellabs.github.io/block-explorer-v2/beta-2";
+    pub const BETA_3: &str = "https://fuellabs.github.io/block-explorer-v2/beta-3";
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,13 @@
 mod account;
+mod balance;
 mod import;
 mod new;
 mod sign;
 mod utils;
+
+use balance::Balance;
+pub use forc_wallet::explorer;
+pub use forc_wallet::network;
 
 use crate::{
     account::{Account, Accounts},
@@ -11,7 +16,7 @@ use crate::{
     sign::Sign,
 };
 use anyhow::Result;
-use clap::{Args, Parser, Subcommand};
+use clap::{Parser, Subcommand};
 use std::path::PathBuf;
 
 #[derive(Debug, Parser)]
@@ -59,33 +64,6 @@ enum Command {
     /// Only includes accounts that have been previously derived, i.e. those
     /// that show under `forc-wallet accounts`.
     Balance(Balance),
-}
-
-#[derive(Debug, Args)]
-struct Balance {
-    // Account-specific args.
-    #[clap(flatten)]
-    account: account::Balance,
-    /// Show the balance for each individual non-empty account before showing
-    /// the total.
-    #[clap(long)]
-    accounts: bool,
-}
-
-/// The default network used in the case that none is specified.
-mod network {
-    pub(crate) const DEFAULT: &str = BETA_3;
-    pub(crate) const BETA_2: &str = "https://node-beta-2.fuel.network";
-    pub(crate) const BETA_2_FAUCET: &str = "https://faucet-beta-2.fuel.network";
-    pub(crate) const BETA_3: &str = "https://beta-3.fuel.network/";
-    pub(crate) const BETA_3_FAUCET: &str = "https://faucet-beta-3.fuel.network/";
-}
-
-/// Contains definitions of URLs to the block explorer for each network.
-mod explorer {
-    pub(crate) const DEFAULT: &str = BETA_3;
-    pub(crate) const BETA_2: &str = "https://fuellabs.github.io/block-explorer-v2/beta-2";
-    pub(crate) const BETA_3: &str = "https://fuellabs.github.io/block-explorer-v2/beta-3";
 }
 
 const ABOUT: &str = "A forc plugin for generating or importing wallets using BIP39 phrases.";
@@ -149,7 +127,7 @@ async fn main() -> Result<()> {
         Command::Accounts(accounts) => account::print_accounts_cli(&wallet_path, accounts)?,
         Command::Account(account) => account::cli(&wallet_path, account).await?,
         Command::Sign(sign) => sign::cli(&wallet_path, sign)?,
-        Command::Balance(balance) => account::balance_cli(&wallet_path, &balance).await?,
+        Command::Balance(balance) => balance::cli(&wallet_path, &balance).await?,
     }
     Ok(())
 }

--- a/src/new.rs
+++ b/src/new.rs
@@ -3,7 +3,7 @@ use crate::utils::{
 };
 use std::path::Path;
 
-pub(crate) fn new_wallet_cli(wallet_path: &Path) -> anyhow::Result<()> {
+pub fn new_wallet_cli(wallet_path: &Path) -> anyhow::Result<()> {
     let password = request_new_password();
     // Generate a random mnemonic phrase.
     let mnemonic = fuels_signers::wallet::generate_mnemonic_phrase(&mut rand::thread_rng(), 24)?;

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -60,7 +60,7 @@ pub enum Data {
     Hex { hex_string: String },
 }
 
-pub(crate) fn cli(wallet_path: &Path, sign: Sign) -> Result<()> {
+pub fn cli(wallet_path: &Path, sign: Sign) -> Result<()> {
     let Sign {
         account,
         private_key,


### PR DESCRIPTION
closes #100.

In a recent tooling sync we talked about splitting lib functionality of `forc-wallet` into two parts:

1. Exposing cli bindings
2. Exposing all the functionality as pure functions (which does not require any CLI interaction)

This completes the first part, any `forc-wallet` command that is useable from CLI should also be useable consuming `forc-wallet` as lib with this PR.