### PR TITLE
refactor: expose balance collecting and printing functionality

### DIFF
--- a/src/account.rs
+++ b/src/account.rs
@@ -227,7 +227,6 @@ pub(crate) fn verify_address_and_update_cache(
     expected_addr: &Bech32Address,
     wallet_ciphertext: &[u8],
 ) -> Result<bool> {
-    println!("Verifying account {acc_ix}");
     let addr = account.address();
     if addr == expected_addr {
         return Ok(true);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod account;
+pub mod balance;
 pub mod import;
 pub mod new;
 pub mod sign;


### PR DESCRIPTION
This PR exposes some balance related functionality so that `forc-deploy` can use them to print and collect account information for balance queries.