### PR TITLE
fix: forc-wallet balance command panics after clap v4 update

### DIFF
--- a/src/balance.rs
+++ b/src/balance.rs
@@ -18,6 +18,7 @@ use crate::{
 };
 
 #[derive(Debug, Args)]
+#[group(skip)]
 pub struct Balance {
     // Account-specific args.
     #[clap(flatten)]


### PR DESCRIPTION
closes #122.

This was caused by a breaking change, in clap. [Here](https://github.com/clap-rs/clap/discussions/4306) is a discussion in clap's repo for the solution.