### PR TITLE
feat: point to beta-4 faucet and block explorer by default

### DIFF
--- a/src/account.rs
+++ b/src/account.rs
@@ -244,9 +244,11 @@ pub(crate) fn verify_address_and_update_cache(
 pub(crate) fn print_balance_empty(node_url: &Url) {
     let beta_2_url = crate::network::BETA_2.parse::<Url>().unwrap();
     let beta_3_url = crate::network::BETA_3.parse::<Url>().unwrap();
+    let beta_4_url = crate::network::BETA_4.parse::<Url>().unwrap();
     let faucet_url = match node_url.host_str() {
         host if host == beta_2_url.host_str() => crate::network::BETA_2_FAUCET,
         host if host == beta_3_url.host_str() => crate::network::BETA_3_FAUCET,
+        host if host == beta_4_url.host_str() => crate::network::BETA_4_FAUCET,
         _ => return println!("  Account empty."),
     };
     println!(
@@ -488,8 +490,11 @@ pub(crate) async fn transfer_cli(
         .await?;
 
     let block_explorer_url = match transfer.node_url.host_str() {
-        host if host == crate::network::BETA_3.parse::<Url>().unwrap().host_str() => {
+        host if host == crate::network::BETA_4.parse::<Url>().unwrap().host_str() => {
             crate::explorer::DEFAULT
+        }
+        host if host == crate::network::BETA_3.parse::<Url>().unwrap().host_str() => {
+            crate::explorer::BETA_3
         }
         host if host == crate::network::BETA_2.parse::<Url>().unwrap().host_str() => {
             crate::explorer::BETA_2

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,16 +7,19 @@ pub mod utils;
 
 /// The default network used in the case that none is specified.
 pub mod network {
-    pub const DEFAULT: &str = BETA_3;
+    pub const DEFAULT: &str = BETA_4;
     pub const BETA_2: &str = "https://node-beta-2.fuel.network";
     pub const BETA_2_FAUCET: &str = "https://faucet-beta-2.fuel.network";
     pub const BETA_3: &str = "https://beta-3.fuel.network/";
     pub const BETA_3_FAUCET: &str = "https://faucet-beta-3.fuel.network/";
+    pub const BETA_4: &str = "https://beta-4.fuel.network/";
+    pub const BETA_4_FAUCET: &str = "https://faucet-beta-4.fuel.network/";
 }
 
 /// Contains definitions of URLs to the block explorer for each network.
 pub mod explorer {
-    pub const DEFAULT: &str = BETA_3;
+    pub const DEFAULT: &str = BETA_4;
     pub const BETA_2: &str = "https://fuellabs.github.io/block-explorer-v2/beta-2";
     pub const BETA_3: &str = "https://fuellabs.github.io/block-explorer-v2/beta-3";
+    pub const BETA_4: &str = "https://fuellabs.github.io/block-explorer-v2/beta-4";
 }


### PR DESCRIPTION
closes #133.

With this PR `forc-wallet` points to beta-4 network by default. ~Waiting for block explorer URL to be confirmed.~