### PR TITLE
chore: bump to v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -899,7 +899,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "forc-wallet"
-version = "0.2.5"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forc-wallet"
-version = "0.2.5"
+version = "0.3.0"
 edition = "2021"
 homepage = "https://fuel.network/"
 license = "Apache-2.0"


### PR DESCRIPTION
Publishing v0.3.0 forc-wallet which supports beta-4 network.