### PR TITLE
Update CI to use tag name instead of ref_name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,7 @@ jobs:
         run: |
           curl -sSLf "https://github.com/TomWright/dasel/releases/download/v1.24.3/dasel_linux_amd64" -L -o dasel && chmod +x dasel
           mv ./dasel /usr/local/bin/dasel
-          ./.github/workflows/scripts/verify_tag.sh ${{ github.ref_name }} Cargo.toml
+          ./.github/workflows/scripts/verify_tag.sh ${{ github.event.release.tag_name }} Cargo.toml
 
       - name: Publish crate
         uses: katyo/publish-crates@v1


### PR DESCRIPTION
For some reason the `github.ref_name` was empty for this run, causing the publishing step to fail: https://github.com/FuelLabs/forc-wallet/actions/runs/5999212274

We'll try a fresh release, and if it fails again we can recreate the release with this change.