### PR TITLE
refactor: use common forc utils for formatting error & warning output

### DIFF
--- a/src/account.rs
+++ b/src/account.rs
@@ -5,6 +5,7 @@ use crate::utils::{
 use anyhow::{anyhow, bail, Context, Result};
 use clap::{Args, Subcommand};
 use eth_keystore::EthKeystore;
+use forc_tracing::println_warning;
 use fuel_crypto::{PublicKey, SecretKey};
 use fuel_types::AssetId;
 use fuels::{
@@ -230,12 +231,13 @@ pub(crate) fn verify_address_and_update_cache(
     if addr == expected_addr {
         return Ok(true);
     }
-    println!(
-        "WARNING: Cached address for account {acc_ix} differs from derived address.\n  \
-          Cached:  {expected_addr}
-          Derived: {addr}
-        Updating cache with newly derived address.",
-    );
+    println_warning(&format!(
+        "Cached address for account {} differs from derived address.\n  \
+        Cached:  {}
+        Derived: {}
+      Updating cache with newly derived address.",
+        acc_ix, expected_addr, addr,
+    ));
     cache_address(wallet_ciphertext, acc_ix, addr)?;
     Ok(false)
 }

--- a/src/account.rs
+++ b/src/account.rs
@@ -232,11 +232,11 @@ pub(crate) fn verify_address_and_update_cache(
         return Ok(true);
     }
     println_warning(&format!(
-        "Cached address for account {} differs from derived address.\n  \
-        Cached:  {}
-        Derived: {}
-      Updating cache with newly derived address.",
-        acc_ix, expected_addr, addr,
+        "Cached address for account {} differs from derived address.\n\
+{:>2}Cached: {}
+{:>2}Derived: {}
+{:>2}Updating cache with newly derived address.",
+        acc_ix, "", expected_addr, "", addr, "",
     ));
     cache_address(wallet_ciphertext, acc_ix, addr)?;
     Ok(false)

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -70,7 +70,7 @@ pub(crate) fn request_new_password() -> String {
     let confirmation = rpassword::prompt_password("Please confirm your password: ").unwrap();
 
     if password != confirmation {
-        println!("Passwords do not match -- try again!");
+        println_warning("Passwords do not match -- try again!");
         std::process::exit(1);
     }
     password


### PR DESCRIPTION
close #150

Refer to [Comment](https://github.com/FuelLabs/forc-wallet/pull/148#discussion_r1410041380)

I have reviewed whole forc-wallet project codes, all warning output that using `println!` has changed to `println_warning`

----
## Screenshots
### For `Password do not match`
#### Before
![image](https://github.com/FuelLabs/forc-wallet/assets/150114626/4dc8c5d9-94b3-48e5-a797-b9115eb78157)

#### After
![image](https://github.com/FuelLabs/forc-wallet/assets/150114626/bdfeaf04-9768-44eb-b821-1fd6a3f156b1)

### For `Cached address for account`
#### Before
![image](https://github.com/FuelLabs/forc-wallet/assets/150114626/3c0a4b65-ce2a-406e-b674-12b70e1082fe)

#### After
![image](https://github.com/FuelLabs/forc-wallet/assets/150114626/f1850c17-1456-4aa0-8db8-2f3be42c23ba)
