### PR TITLE
chore: expose new options for new_cli so that it can be used outside this repo

### DIFF
--- a/src/new.rs
+++ b/src/new.rs
@@ -10,7 +10,7 @@ use std::{io::stdin, path::Path};
 pub struct New {
     /// Forces wallet creation, removing any existing wallet file
     #[clap(short, long)]
-    force: bool,
+    pub force: bool,
 }
 
 pub fn new_wallet_cli(wallet_path: &Path, new: New) -> anyhow::Result<()> {


### PR DESCRIPTION
It turns out we need it for forc-client as new options changed since last release and I failed to realize