### PR TITLE
chore: bump to v0.8.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1018,7 +1018,7 @@ dependencies = [
 
 [[package]]
 name = "forc-wallet"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forc-wallet"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 homepage = "https://fuel.network/"
 license = "Apache-2.0"


### PR DESCRIPTION
Made this a minor bump as fuel-core compatibility is not effected from v0.8.0, also no breaking api changes.