### PR TITLE
ci: add code coverage reports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -D warnings
   REGISTRY: ghcr.io
+  RUST_VERSION_COV: nightly-2024-06-05
 
 jobs:
   cancel-previous-runs:
@@ -21,6 +22,36 @@ jobs:
         uses: styfle/cancel-workflow-action@0.9.1
         with:
           access_token: ${{ github.token }}
+
+  publish-codecov:
+    name: Check code coverage (branch)
+    runs-on: ubuntu-latest
+    permissions: # Write access to push changes to pages
+      contents: write
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install latest Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_VERSION_COV }}
+
+      - name: Install cargo-llvm-codecov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Code coverage report
+        run: cargo  +${{ env.RUST_VERSION_COV }} llvm-cov --all-features --lcov --branch --output-path lcov.info
+
+      - name: Setup LCOV
+        uses: hrishikesh-kadam/setup-lcov@v1
+
+      - name: Report code coverage
+        uses: zgosalvez/github-actions-report-lcov@v3
+        with:
+          coverage-files: lcov.info
+          minimum-coverage: 0 # for now we are not enforcing any minimum coverage.
+          artifact-name: code-coverage-report
+          github-token: ${{ secrets.REPO_TOKEN }}
+          update-comment: true
 
   lint-toml-files:
     needs: cancel-previous-runs


### PR DESCRIPTION
closes #193.

Adds code coverage reporting step to CI. Once we have #192 merged, coverage should increase dramatically.