### PR TITLE
feat: print plain addresses by default

### DIFF
--- a/src/balance.rs
+++ b/src/balance.rs
@@ -140,7 +140,7 @@ pub(crate) async fn list_account_balances(
     }
     let accounts: Vec<_> = addresses
         .values()
-        .map(|addr| Wallet::from_address(addr.clone().into(), Some(provider.clone())))
+        .map(|addr| Wallet::from_address((*addr).into(), Some(provider.clone())))
         .collect();
     let account_balances =
         futures::future::try_join_all(accounts.iter().map(|acc| acc.get_balances())).await?;

--- a/src/list.rs
+++ b/src/list.rs
@@ -33,7 +33,7 @@ pub async fn list_wallet_cli(wallet_path: &Path, opts: List) -> Result<()> {
         opts.target_accounts,
     )?
     .range(0..opts.target_accounts.unwrap_or(1))
-    .map(|(a, b)| (*a, b.clone()))
+    .map(|(a, b)| (*a, *b))
     .collect::<BTreeMap<_, _>>();
 
     let (account_balances, total_balance) =


### PR DESCRIPTION
closes #198.

We are now printing plain addressed from forc-wallet if bech32 is not explicitly requested by the user.