### PR TITLE
feat: implement check sum reporting and update default target

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1019,9 +1019,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-asm"
-version = "0.58.0"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79ca07227658105bdf873556dea09fa7fbfe792fbc084b4b9568f5ba3d64c411"
+checksum = "5f325971bf9047ec70004f80a989e03456316bc19cbef3ff3a39a38b192ab56e"
 dependencies = [
  "bitflags 2.6.0",
  "fuel-types",
@@ -1031,9 +1031,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-chain-config"
-version = "0.37.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd1eca1d12daf8ad0f2479d7fff9405d94b6467496e5319e5f8b99cbdabdd58b"
+checksum = "0209e3f661836ce4076de68560918fc10423b03f1e3ad064943be38fd42e1021"
 dependencies = [
  "anyhow",
  "bech32",
@@ -1051,9 +1051,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-client"
-version = "0.37.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dbd88f285afdf061e409b712ecef49e2fe9ba235288cc76e8de8f05d50b6876"
+checksum = "96d009d6724a61cd502755a44f3096dba5d63702409db5144ab5e45ebbd17a37"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1076,9 +1076,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-metrics"
-version = "0.37.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc199e165e600f241cab86129766b26bab78572a701a39bc40a5fdb669961a8"
+checksum = "606e3b2d369006efa8bc72551233a6ee95714342cb77fc7ef157f3a5e4bbb366"
 dependencies = [
  "parking_lot",
  "pin-project-lite",
@@ -1089,9 +1089,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-poa"
-version = "0.37.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49c4f3e5fa1e916793609bdb9a52142077a84a793272379a04cf24375aa94e6f"
+checksum = "88c7b9ef332ac4d5acf6269187f6ff6c2d12888b8ef9a6e5bf9acab59948fe23"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1108,9 +1108,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-services"
-version = "0.37.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "739dca83db1eb86651db3833f088f52afcd3f181cfca40e5725074aceb3ea49d"
+checksum = "b9b6efff01e6b29106a07c7b125021258ba34bdbc68b7d089a956a013042558a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1123,9 +1123,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-storage"
-version = "0.37.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6255d852b6866199d103233e1eef2e7ded141019bc782b5b211fcf001727c34b"
+checksum = "bf6d323c90fe47960b5d769e18739866a3ccaa69353b5ad50b0b952365ccce4c"
 dependencies = [
  "anyhow",
  "derive_more",
@@ -1145,9 +1145,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-types"
-version = "0.37.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33a4e9b2de06381e1ad598cd1030344993fee7401331ca9955d0a1860cc0484c"
+checksum = "260bce919b2bf8ddf8f6a5804cd917cef861f7f3d745ae95440e4151c35e459c"
 dependencies = [
  "anyhow",
  "bs58",
@@ -1163,9 +1163,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-crypto"
-version = "0.58.0"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f53b06525aa7754bf7c3ef23daf15fd798ae990a82f8b7b813d25cedfeacfe5c"
+checksum = "65e318850ca64890ff123a99b6b866954ef49da94ab9bc6827cf6ee045568585"
 dependencies = [
  "coins-bip32",
  "coins-bip39",
@@ -1184,9 +1184,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-derive"
-version = "0.58.0"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e34d6eec30d04506607cc0bc85fc97c57c964580cd233fd557e346c5273535"
+checksum = "ab0bc46a3552964bae5169e79b383761a54bd115ea66951a1a7a229edcefa55a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1196,9 +1196,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-merkle"
-version = "0.58.0"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9fa3708405eba32fd2b947b827dc52484377ba6a238260b03a07b642395e6c"
+checksum = "c79eca6a452311c70978a5df796c0f99f27e474b69719e0db4c1d82e68800d07"
 dependencies = [
  "derive_more",
  "digest",
@@ -1211,15 +1211,15 @@ dependencies = [
 
 [[package]]
 name = "fuel-storage"
-version = "0.58.0"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f678f1c900d0632d77e15d4a4946048d4d517fefeba72607390c03288ca127"
+checksum = "2d0c46b5d76b3e11197bd31e036cd8b1cb46c4d822cacc48836638080c6d2b76"
 
 [[package]]
 name = "fuel-tx"
-version = "0.58.0"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e3065c12eecc9121514694f4b01009c9a83d8842af11c43ec9e2bbc0a7f36cb"
+checksum = "6723bb8710ba2b70516ac94d34459593225870c937670fb3afaf82e0354667ac"
 dependencies = [
  "bitflags 2.6.0",
  "derivative",
@@ -1239,9 +1239,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-types"
-version = "0.58.0"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a93d5f3fd028d874d8927be439fcdea01cb04499049bc68a874c73dd0c7e32b7"
+checksum = "982265415a99b5bd6277bc24194a233bb2e18764df11c937b3dbb11a02c9e545"
 dependencies = [
  "fuel-derive",
  "hex",
@@ -1251,9 +1251,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-vm"
-version = "0.58.0"
+version = "0.58.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb0562398978e501e8ee2caeb747a2852cc4a8c5fff250eb58e38f1c03217311"
+checksum = "54b5362d7d072c72eec20581f67fc5400090c356a7f3ae77c79880b3b177b667"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1285,9 +1285,9 @@ dependencies = [
 
 [[package]]
 name = "fuels"
-version = "0.66.6"
+version = "0.66.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "921a8ea521744e600e0a34236adff7524ecf34bd940c2a018315d0212c140d7b"
+checksum = "0cc9fd04c82c0ad54f05dc7559d3b3a578856e9d2571f90f598e82c547b13b11"
 dependencies = [
  "fuel-core-client",
  "fuel-crypto",
@@ -1301,12 +1301,13 @@ dependencies = [
 
 [[package]]
 name = "fuels-accounts"
-version = "0.66.6"
+version = "0.66.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2da8bad87e947fc448c44c22e4c90a4af49d61de08722b1d1774d977b2071047"
+checksum = "37d1d3f3e0a58b93c8ed4499bffbc7f4b84de20412d539e59399ae2347df498b"
 dependencies = [
  "async-trait",
  "chrono",
+ "cynic",
  "elliptic-curve",
  "eth-keystore",
  "fuel-core-client",
@@ -1326,9 +1327,9 @@ dependencies = [
 
 [[package]]
 name = "fuels-code-gen"
-version = "0.66.6"
+version = "0.66.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fdc5f9dcdf330f5ef5f367dbc2334e72151e9ae46a4ee9f21d43a5e859be11b"
+checksum = "c2cc82b492092e1d9cacd12eef8d52604609a2a5a93b720d5cf07e2638ffdaaf"
 dependencies = [
  "Inflector",
  "fuel-abi-types",
@@ -1342,9 +1343,9 @@ dependencies = [
 
 [[package]]
 name = "fuels-core"
-version = "0.66.6"
+version = "0.66.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "629212e8278d57aa1a6f846ca0ca1e3428fb6da2d43e368931ff1494a0a6b5ce"
+checksum = "061f9f69c778aa47db790c5d8787650192e96250629d2762dc41bfb81cf2269d"
 dependencies = [
  "async-trait",
  "bech32",
@@ -1364,15 +1365,16 @@ dependencies = [
  "postcard",
  "serde",
  "serde_json",
+ "sha2",
  "thiserror",
  "uint",
 ]
 
 [[package]]
 name = "fuels-macros"
-version = "0.66.6"
+version = "0.66.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562bf012adedfb492431f4bfd5be4ccbf2171ab7d5247c5953a6be3ea8036072"
+checksum = "c16ee5a68f88cc26930c599c7e9642ed25283d2349dc2679e66cdc648e6d4db0"
 dependencies = [
  "fuels-code-gen",
  "itertools 0.12.1",
@@ -1383,9 +1385,9 @@ dependencies = [
 
 [[package]]
 name = "fuels-programs"
-version = "0.66.6"
+version = "0.66.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a366e6a78e1c104fe1cb14439199833987fe76ecd46ee2b46fe05868a3366d"
+checksum = "8b969332a841486557e2d438b59214369c9823a535b302f3f2039287eba1e12e"
 dependencies = [
  "async-trait",
  "fuel-abi-types",
@@ -1402,9 +1404,9 @@ dependencies = [
 
 [[package]]
 name = "fuels-test-helpers"
-version = "0.66.6"
+version = "0.66.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7705708c0fe28a874c44635b77c3e120a3422c8a24fdc45f07dc8c21ee9ca6fb"
+checksum = "3cfcc78a5079fb3621628e24183be0777591c4cfe172baea492f8d67134ad07f"
 dependencies = [
  "fuel-core-chain-config",
  "fuel-core-client",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,12 +14,12 @@ eth-keystore = { version = "0.5" }
 forc-tracing = "0.47.0"
 
 # Dependencies from the `fuel-vm` repository:
-fuel-crypto = { version = "0.58.0" }
-fuel-types = { version = "0.58.0" }
+fuel-crypto = { version = "0.58.2" }
+fuel-types = { version = "0.58.2" }
 
 # Dependencies from the `fuels-rs` repository:
-fuels = "0.66.6" 
-fuels-core = "0.66.6" 
+fuels = "0.66.8" 
+fuels-core = "0.66.8" 
 
 futures = "0.3"
 hex = "0.4"

--- a/src/account.rs
+++ b/src/account.rs
@@ -529,8 +529,11 @@ pub(crate) async fn transfer_cli(
         .await?;
 
     let block_explorer_url = match transfer.node_url.host_str() {
-        host if host == crate::network::TESTNET.parse::<Url>().unwrap().host_str() => {
+        host if host == crate::network::MAINNET.parse::<Url>().unwrap().host_str() => {
             crate::explorer::DEFAULT
+        }
+        host if host == crate::network::TESTNET.parse::<Url>().unwrap().host_str() => {
+            crate::explorer::TESTNET
         }
         host if host == crate::network::BETA_5.parse::<Url>().unwrap().host_str() => {
             crate::explorer::BETA_5

--- a/src/account.rs
+++ b/src/account.rs
@@ -131,21 +131,25 @@ enum To {
 }
 
 impl FromStr for To {
-    type Err = &'static str;
+    type Err = String;
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         if let Ok(bech32_address) = Bech32Address::from_str(s) {
             return Ok(Self::Bech32Address(bech32_address));
         } else if let Ok(hex_address) = fuel_types::Address::from_str(s) {
             if !is_checksum_valid(s) {
-                return Err(
+                return Err(format!(
                     "Checksum is not valid for address `{}`, the address might not be an account.",
-                );
+                    s
+                ));
             }
             return Ok(Self::HexAddress(hex_address));
         }
 
-        Err("Invalid address '{}': address must either be in bech32 or hex")
+        Err(format!(
+            "Invalid address '{}': address must either be in bech32 or hex",
+            s
+        ))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,6 @@ pub mod explorer {
     pub const BETA_3: &str = "https://fuellabs.github.io/block-explorer-v2/beta-3";
     pub const BETA_4: &str = "https://fuellabs.github.io/block-explorer-v2/beta-4";
     pub const BETA_5: &str = "https://fuellabs.github.io/block-explorer-v2/beta-5";
-    pub const TESTNET: &str = "https://app.fuel.network/";
-    pub const MAINNET: &str = "https://app.fuel.network/";
+    pub const TESTNET: &str = "https://app-testnet.fuel.network";
+    pub const MAINNET: &str = "https://app.fuel.network";
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ pub const DEFAULT_CACHE_ACCOUNTS: usize = 1;
 
 /// The default network used in the case that none is specified.
 pub mod network {
-    pub const DEFAULT: &str = TESTNET;
+    pub const DEFAULT: &str = MAINNET;
     pub const BETA_2: &str = "https://node-beta-2.fuel.network";
     pub const BETA_2_FAUCET: &str = "https://faucet-beta-2.fuel.network";
     pub const BETA_3: &str = "https://beta-3.fuel.network/";
@@ -22,14 +22,16 @@ pub mod network {
     pub const BETA_5_FAUCET: &str = "https://faucet-beta-5.fuel.network/";
     pub const TESTNET: &str = "https://testnet.fuel.network/";
     pub const TESTNET_FAUCET: &str = "https://faucet-testnet.fuel.network/";
+    pub const MAINNET: &str = "https://mainnet.fuel.network/";
 }
 
 /// Contains definitions of URLs to the block explorer for each network.
 pub mod explorer {
-    pub const DEFAULT: &str = TESTNET;
+    pub const DEFAULT: &str = MAINNET;
     pub const BETA_2: &str = "https://fuellabs.github.io/block-explorer-v2/beta-2";
     pub const BETA_3: &str = "https://fuellabs.github.io/block-explorer-v2/beta-3";
     pub const BETA_4: &str = "https://fuellabs.github.io/block-explorer-v2/beta-4";
     pub const BETA_5: &str = "https://fuellabs.github.io/block-explorer-v2/beta-5";
     pub const TESTNET: &str = "https://app.fuel.network/";
+    pub const MAINNET: &str = "https://app.fuel.network/";
 }

--- a/src/list.rs
+++ b/src/list.rs
@@ -38,7 +38,7 @@ pub async fn list_wallet_cli(wallet_path: &Path, opts: List) -> Result<()> {
 
     let (account_balances, total_balance) =
         list_account_balances(&opts.node_url, &addresses).await?;
-    print_account_balances(&addresses, &account_balances);
+    print_account_balances(&addresses, &account_balances)?;
     println!("\nTotal:");
     if total_balance.is_empty() {
         print_balance_empty(&opts.node_url);

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,7 @@ enum Command {
     /// If a '--fore' is specified, will automatically removes the existing wallet at the same
     /// path.
     New(New),
-    /// TODO: List all wallets in the default wallet directory.
+    /// List all wallets in the default wallet directory.
     List(List),
     /// Import a wallet from the provided mnemonic phrase.
     ///


### PR DESCRIPTION
This PR implements couple of things:

1. Adds a new target
2. Adds checksum routines at places where we print user account, and accept user account (transfer to address).
3. Bumps sdk version to latest, 0.66.8.


### Checksum support

1. At the places where we output hex address we now output checksum encoded hex address so that copied and pasted into any other wallet, users will not face any warning. 
2. At places where we accept a user account address, (currently only `transfer`'s `to` field), we query the provider to see if this account actually belongs to an user (i.e it is not a blob id, contract id etc).

I needed to add an unwrap, at a place where I am sure that the result is not going to be failing. After this release I will remove it by rewriting the transfer section of the wallet.


We first check if the checksum is valid while parsing the `To ` field. If that is not the case that is an immediate error. If it is indeed with the correct checksum then we proceed to querying the provider to see if it is an actual address.


### Couple of examples
Here I try to transfer some funds to a contract, which has invalid 

![image](https://github.com/user-attachments/assets/9843f4a6-4020-431a-b217-47ddd5a04817)

Here i try to transfer to my account with valid check sum.

![image](https://github.com/user-attachments/assets/155866d0-4e92-43ad-b7fa-0e4200db8047)


