### PR TITLE
chore: bump sdk to v0.66.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1031,9 +1031,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-chain-config"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0209e3f661836ce4076de68560918fc10423b03f1e3ad064943be38fd42e1021"
+checksum = "990db3029efd3766c4ae7c92a53c159ae66abf6f568ac6a3d58354f11400e6e2"
 dependencies = [
  "anyhow",
  "bech32",
@@ -1051,9 +1051,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-client"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96d009d6724a61cd502755a44f3096dba5d63702409db5144ab5e45ebbd17a37"
+checksum = "f09b3a35e82226d77b10653829beb508dc4bcf698fbdaa96610faf894e794444"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1076,22 +1076,25 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-metrics"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "606e3b2d369006efa8bc72551233a6ee95714342cb77fc7ef157f3a5e4bbb366"
+checksum = "94a1c3eb92040d95d27f7c658801bb5c04ad4aaf67de380cececbeed5aab6e61"
 dependencies = [
+ "once_cell",
  "parking_lot",
  "pin-project-lite",
  "prometheus-client",
  "regex",
+ "strum 0.25.0",
+ "strum_macros 0.25.3",
  "tracing",
 ]
 
 [[package]]
 name = "fuel-core-poa"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88c7b9ef332ac4d5acf6269187f6ff6c2d12888b8ef9a6e5bf9acab59948fe23"
+checksum = "2f6f78fa31dc56b9458e3ca9a7058b4bea381e16e49fcab0db49923be8a30f9c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1108,24 +1111,25 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-services"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9b6efff01e6b29106a07c7b125021258ba34bdbc68b7d089a956a013042558a"
+checksum = "8312b598da4b9a6503c9263c1c2a7ea58d34ab1f86e7f345490e12d309fb29bb"
 dependencies = [
  "anyhow",
  "async-trait",
  "fuel-core-metrics",
  "futures",
  "parking_lot",
+ "pin-project-lite",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "fuel-core-storage"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf6d323c90fe47960b5d769e18739866a3ccaa69353b5ad50b0b952365ccce4c"
+checksum = "bda9242ebc9e8ef3251b9eae85f4ce5cdb376348baa30925606f3ce602db7ec5"
 dependencies = [
  "anyhow",
  "derive_more",
@@ -1145,9 +1149,9 @@ dependencies = [
 
 [[package]]
 name = "fuel-core-types"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "260bce919b2bf8ddf8f6a5804cd917cef861f7f3d745ae95440e4151c35e459c"
+checksum = "6ee3a95b189bf729d21354a761862bb481298cbd883550adc3fef1bc7beb0b67"
 dependencies = [
  "anyhow",
  "bs58",
@@ -1285,9 +1289,9 @@ dependencies = [
 
 [[package]]
 name = "fuels"
-version = "0.66.8"
+version = "0.66.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc9fd04c82c0ad54f05dc7559d3b3a578856e9d2571f90f598e82c547b13b11"
+checksum = "6ed08053e72bdb285d5a167c27a7a0d10f1dc4e27d1e6e5296dd2a67813bd13f"
 dependencies = [
  "fuel-core-client",
  "fuel-crypto",
@@ -1301,9 +1305,9 @@ dependencies = [
 
 [[package]]
 name = "fuels-accounts"
-version = "0.66.8"
+version = "0.66.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d1d3f3e0a58b93c8ed4499bffbc7f4b84de20412d539e59399ae2347df498b"
+checksum = "49fee90e8f3a4fc9392a6cde3010c561fa50da0f805d66fdb659eaa4d5d8a504"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1327,9 +1331,9 @@ dependencies = [
 
 [[package]]
 name = "fuels-code-gen"
-version = "0.66.8"
+version = "0.66.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2cc82b492092e1d9cacd12eef8d52604609a2a5a93b720d5cf07e2638ffdaaf"
+checksum = "f857b7ff658400506ca6be57bb84fedda44b566e78f5f0a8d0782242f41615c0"
 dependencies = [
  "Inflector",
  "fuel-abi-types",
@@ -1343,9 +1347,9 @@ dependencies = [
 
 [[package]]
 name = "fuels-core"
-version = "0.66.8"
+version = "0.66.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "061f9f69c778aa47db790c5d8787650192e96250629d2762dc41bfb81cf2269d"
+checksum = "baccbdd81e624f57950dcb136b32b853c520dd954badf26b9f58de33f3d71c7e"
 dependencies = [
  "async-trait",
  "bech32",
@@ -1372,9 +1376,9 @@ dependencies = [
 
 [[package]]
 name = "fuels-macros"
-version = "0.66.8"
+version = "0.66.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c16ee5a68f88cc26930c599c7e9642ed25283d2349dc2679e66cdc648e6d4db0"
+checksum = "5da75294c5e9da312bdc49239736699ee84ea9c5bfbc19a61a8ee588a1247aa1"
 dependencies = [
  "fuels-code-gen",
  "itertools 0.12.1",
@@ -1385,9 +1389,9 @@ dependencies = [
 
 [[package]]
 name = "fuels-programs"
-version = "0.66.8"
+version = "0.66.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b969332a841486557e2d438b59214369c9823a535b302f3f2039287eba1e12e"
+checksum = "32675ed1c08edd28ddb648dfae0c60a1946d4368a69ddfa6434f2316e33f0520"
 dependencies = [
  "async-trait",
  "fuel-abi-types",
@@ -1404,9 +1408,9 @@ dependencies = [
 
 [[package]]
 name = "fuels-test-helpers"
-version = "0.66.8"
+version = "0.66.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cfcc78a5079fb3621628e24183be0777591c4cfe172baea492f8d67134ad07f"
+checksum = "02176c0fb1bf8cf58b8a9e5372efb650324740abcd4847b45bd0b041a0f133a2"
 dependencies = [
  "fuel-core-chain-config",
  "fuel-core-client",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,8 @@ fuel-crypto = { version = "0.58.2" }
 fuel-types = { version = "0.58.2" }
 
 # Dependencies from the `fuels-rs` repository:
-fuels = "0.66.8" 
-fuels-core = "0.66.8" 
+fuels = "0.66.9" 
+fuels-core = "0.66.9" 
 
 futures = "0.3"
 hex = "0.4"


### PR DESCRIPTION
Bumps sdk version to v0.66.9