### PR TITLE
Import struct force var public visibility

### DIFF
--- a/src/import.rs
+++ b/src/import.rs
@@ -15,7 +15,7 @@ use std::{io::stdin, path::Path};
 pub struct Import {
     /// Forces wallet creation, removing any existing wallet file
     #[clap(short, long)]
-    force: bool,
+    pub force: bool,
     /// How many accounts to cache by default (Default 10)
     #[clap(short, long)]
     pub cache_accounts: Option<usize>,


### PR DESCRIPTION
# Changelog

- `force` var in the `Import` struct made public

# Context

This is required to address https://github.com/FuelLabs/forc-wallet/issues/139 as we need to support importing wallet - which requires instantiating the `Import` struct