### PR TITLE
feat: wallet export

### DIFF
--- a/src/export.rs
+++ b/src/export.rs
@@ -4,7 +4,7 @@ use rpassword::prompt_password;
 use std::path::Path;
 
 /// Decrypts a wallet using provided password
-fn decrypt_wallet(wallet_path: &Path, password: &str) -> Result<String> {
+fn decrypt_mnemonic(wallet_path: &Path, password: &str) -> Result<String> {
     let phrase_bytes = eth_keystore::decrypt_key(wallet_path, password)
         .map_err(|e| anyhow!("Failed to decrypt keystore: {}", e))?;
 
@@ -15,7 +15,7 @@ fn decrypt_wallet(wallet_path: &Path, password: &str) -> Result<String> {
 pub fn export_wallet_cli(wallet_path: &Path) -> Result<()> {
     let prompt = "Please enter your wallet password to export your wallet: ";
     let password = prompt_password(prompt)?;
-    let phrase = decrypt_wallet(wallet_path, &password)?;
+    let phrase = decrypt_mnemonic(wallet_path, &password)?;
 
     // Display phrase in alternate screen
     display_string_discreetly(
@@ -24,4 +24,20 @@ pub fn export_wallet_cli(wallet_path: &Path) -> Result<()> {
     )?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        export::decrypt_mnemonic,
+        utils::test_utils::{TEST_MNEMONIC, TEST_PASSWORD, with_tmp_dir_and_wallet},
+    };
+
+    #[test]
+    fn decrypt_wallet() {
+        with_tmp_dir_and_wallet(|_dir, wallet_path| {
+            let decrypted_mnemonic = decrypt_mnemonic(wallet_path, TEST_PASSWORD).unwrap();
+            assert_eq!(decrypted_mnemonic, TEST_MNEMONIC)
+        });
+    }
 }

--- a/src/export.rs
+++ b/src/export.rs
@@ -1,0 +1,27 @@
+use crate::utils::display_string_discreetly;
+use anyhow::{Context, Result, anyhow};
+use rpassword::prompt_password;
+use std::path::Path;
+
+/// Decrypts a wallet using provided password
+fn decrypt_wallet(wallet_path: &Path, password: &str) -> Result<String> {
+    let phrase_bytes = eth_keystore::decrypt_key(wallet_path, password)
+        .map_err(|e| anyhow!("Failed to decrypt keystore: {}", e))?;
+
+    String::from_utf8(phrase_bytes).context("Invalid UTF-8 in mnemonic phrase")
+}
+
+/// Prints the wallet at the given path as mnemonic phrase as a discrete string
+pub fn export_wallet_cli(wallet_path: &Path) -> Result<()> {
+    let prompt = "Please enter your wallet password to export your wallet: ";
+    let password = prompt_password(prompt)?;
+    let phrase = decrypt_wallet(wallet_path, &password)?;
+
+    // Display phrase in alternate screen
+    display_string_discreetly(
+        &phrase,
+        "### Do not share or lose this mnemonic phrase! Press any key to complete. ###",
+    )?;
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,9 @@
 use std::path::PathBuf;
-
 use url::Url;
 
 pub mod account;
 pub mod balance;
+pub mod export;
 pub mod format;
 pub mod import;
 pub mod list;

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use forc_wallet::{
     CliContext,
     account::{self, Account, Accounts},
     balance::{self, Balance},
+    export::export_wallet_cli,
     import::{Import, import_wallet_cli},
     list::{List, list_wallet_cli},
     network::DEFAULT as DEFAULT_NODE_URL,
@@ -51,6 +52,10 @@ enum Command {
     /// If a '--fore' is specified, will automatically removes the existing wallet at the same
     /// path.
     Import(Import),
+    /// Export a wallet as a mnemonic phrase.
+    ///
+    /// If a `--path` is specified, the wallet will be read from this location.
+    Export,
     /// Lists all accounts derived for the wallet so far.
     ///
     /// Note that this only includes accounts that have been previously derived
@@ -85,6 +90,12 @@ EXAMPLES:
 
     # Import a new wallet from a mnemonic phrase.
     forc wallet import
+
+    # Export wallet as a mnemonic phrase from default path.
+    forc wallet import
+
+    # Export wallet as a mnemonic phrase read from the given path.
+    forc wallet import --path /path/to/wallet
 
     # Import a new wallet from a mnemonic phrase and automatically replace the existing wallet if it's at the same path.
     forc wallet import --force
@@ -150,6 +161,7 @@ async fn run() -> Result<()> {
         Command::New(new) => new_wallet_cli(&ctx, new).await?,
         Command::List(list) => list_wallet_cli(&ctx, list).await?,
         Command::Import(import) => import_wallet_cli(&ctx, import).await?,
+        Command::Export => export_wallet_cli(&ctx.wallet_path)?,
         Command::Accounts(accounts) => account::print_accounts_cli(&ctx, accounts).await?,
         Command::Account(account) => account::cli(&ctx, account).await?,
         Command::Sign(sign) => sign::cli(&ctx, sign)?,

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,7 +54,7 @@ enum Command {
     Import(Import),
     /// Export a wallet as a mnemonic phrase.
     ///
-    /// If a `--path` is specified, the wallet will be read from this location.
+    /// If a `--path` is specified, the wallet will be read from that location.
     Export,
     /// Lists all accounts derived for the wallet so far.
     ///


### PR DESCRIPTION
closes #237


Adds `forc-wallet export`  and `forc-wallet export --path <PATH>` command to be able to export mnemonic phrase so that it can be imported to the browser wallet.