### PR TITLE
upd forc-tracing 0.67.0 -> 0.68.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1063,7 +1063,7 @@ dependencies = [
 
 [[package]]
 name = "forc-wallet"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1051,11 +1051,12 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "forc-tracing"
-version = "0.67.0"
+version = "0.68.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c81ec9672413a0cadedb2791aa6208c415523f7f9a430bc8516da00587439ce6"
+checksum = "c36a046da28526264755d87c0b4dfd6e13a5153eb00d271d3a34b8ab1412f224"
 dependencies = [
  "ansiterm",
+ "regex",
  "tracing",
  "tracing-subscriber",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forc-wallet"
-version = "0.15.0"
+version = "0.15.1"
 edition = "2024"
 homepage = "https://fuel.network/"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ description = "A forc plugin for generating or importing wallets using mnemonic 
 anyhow = "1.0"
 clap = { version = "4.2.4", features = ["derive"] }
 eth-keystore = { version = "0.5" }
-forc-tracing = "0.67"
+forc-tracing = "0.68"
 
 # Dependencies from the `fuels-rs` repository:
 fuels = "0.74"


### PR DESCRIPTION
## Description

This pull request includes a version update for the `forc-tracing` dependency in the `Cargo.toml` file.

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L14-R14): Updated the `forc-tracing` dependency from version `0.67` to `0.68`.