### PR TITLE
Fix Typo in Wallet Accounts Directory Path

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -59,7 +59,7 @@ enum Command {
     /// Lists all accounts derived for the wallet so far.
     ///
     /// Note that this only includes accounts that have been previously derived
-    /// *locally* and still exist within the user's `~/.fuel/wallets/accoutns`
+    /// *locally* and still exist within the user's `~/.fuel/wallets/accounts`
     /// cache. If this wallet was recently imported, you may need to re-derive
     /// your accounts.
     ///


### PR DESCRIPTION

---



**Description:**  
This pull request corrects a typo in the inline documentation for the wallet accounts directory path, changing accoutns to accounts for improved clarity and accuracy.